### PR TITLE
rtl: Improve compatibility with Synopsys Design Compiler

### DIFF
--- a/rtl/serv_mpram.v
+++ b/rtl/serv_mpram.v
@@ -44,6 +44,10 @@ module serv_mpram
    reg [2:0] 	     wcnt_hi;
    reg 		     wgo_r;
 
+   reg            trap_r;
+   reg            trap_2r;
+   reg            trap_3r;
+
    assign wdata = wcnt_lo[0] ? wdata0[3:0] : wdata1[3:0];
 
    assign wen = !wgo_r & |(wen_r & wcnt_lo[1:0]);
@@ -68,10 +72,6 @@ module serv_mpram
    assign waddr[2:0] = wcnt_hi;
 
    wire 	     wgo = !(|wcnt_lo) & ((i_run & (i_rd_wen | i_csr_en)) | i_trap);
-
-   reg 		     trap_r;
-   reg 		     trap_2r;
-   reg 		     trap_3r;
 
    always @(posedge i_clk) begin
       trap_r <= i_trap;

--- a/rtl/serv_top.v
+++ b/rtl/serv_top.v
@@ -132,6 +132,9 @@ module serv_top
 
    wire 	 new_irq;
 
+   wire [1:0]   lsb;
+   wire [31:0]  bufreg_out;
+
    serv_state state
      (
       .i_clk (clk),
@@ -225,8 +228,6 @@ module serv_top
       .o_rd_alu_en        (rd_alu_en),
       .o_rd_mem_en        (rd_mem_en));
 
-   wire [1:0] 	 lsb;
-   wire [31:0] 	 bufreg_out;
    assign o_dbus_adr = {bufreg_out[31:2], 2'b00};
 
    serv_bufreg bufreg

--- a/rtl/shift_reg.v
+++ b/rtl/shift_reg.v
@@ -9,7 +9,7 @@ module shift_reg
    output wire 		 o_q,
    output wire [LEN-2:0] o_par);
 
-   reg [LEN-1:0] 	 data = INIT;
+   reg [LEN-1:0] 	 data;
    assign o_q = data[0];
    assign o_par = data[LEN-1:1];
    always @(posedge clk)


### PR DESCRIPTION
Synopysis DC has problems with forward references and initial
statements. Fixed that for better compatibility.