### PR TITLE
Suppressing some verilator lint warnings

### DIFF
--- a/servant/servant.v
+++ b/servant/servant.v
@@ -105,10 +105,12 @@ serv_arbiter serv_arbiter
 //synthesis translate_off
    reg [1023:0] firmware_file;
    initial
+     /* verilator lint_off WIDTH */
      if ($value$plusargs("firmware=%s", firmware_file)) begin
 	$display("Loading RAM from %0s", firmware_file);
 	$readmemh(firmware_file, ram.mem);
      end
+     /* verilator lint_on WIDTH */
 //synthesis translate_on
 `endif
 

--- a/servant/servant_mux.v
+++ b/servant/servant_mux.v
@@ -66,10 +66,12 @@ module serv_mux
 	 integer      f = 0;
 
 	 initial
+       /* verilator lint_off WIDTH */
 	   if ($value$plusargs("signature=%s", signature_file)) begin
 	      $display("Writing signature to %0s", signature_file);
 	      f = $fopen(signature_file, "w");
 	   end
+       /* verilator lint_on WIDTH */
 
 	 always @(posedge i_clk)
 	    if (sig_en & (f != 0))


### PR DESCRIPTION
Can't launch following command without disabling this warning : 
```
$ fusesoc run --target=verilator_tb servant --uart_baudrate=57600 --firmware=$SERV/sw/zephyr_hello.hex
INFO: Preparing ::serv:0
INFO: Preparing ::servant:0

verilator -f servant_0.vc --trace
%Warning-WIDTH: ../src/servant_0/servant/servant_mux.v:69: Logical Operator IF expects 1 bit on the If, but If's VALUEPLUSARGS 'signature=%s' generates 32 bits.
%Warning-WIDTH: Use "/* verilator lint_off WIDTH */" and lint_on around source to disable this message.
%Warning-WIDTH: ../src/servant_0/servant/servant.v:108: Logical Operator IF expects 1 bit on the If, but If's VALUEPLUSARGS 'firmware=%s' generates 32 bits.
%Error: Exiting due to 2 warning(s)
%Error: Command Failed /usr/local/bin/verilator_bin -f servant_0.vc --trace
Makefile:16: recipe for target 'Vservant.mk' failed
make: *** [Vservant.mk] Error 10
```