### PR TITLE
README: --firmware parameter only available for sim and verilator_tb targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pin 9 is used for UART output with 57600 baud rate.
     cd $SERV/workspace
     fusesoc run --target=icebreaker servant
 
-Run with `--firmware=$SERV/sw/blinky.hex` as the last argument to run the LED blink example instead
+Run with `--memfile=$SERV/sw/blinky.hex` as the last argument to run the LED blink example instead
 
 ## Other targets
 


### PR DESCRIPTION
According to servant.core --memfile must be used for all boards. When using --firmware for icebreaker, tinyfpga_bx or nexys_a7, fusesoc fails with:
INFO: Setting up project
usage: fusesoc run servant_0 [-h] [--memfile MEMFILE] [--PLL PLL]
                             [--memsize MEMSIZE] [--RISCV_FORMAL]
                             [--SERV_CLEAR_RAM] [--pnr PNR]
                             [--arachne_pnr_options ARACHNE_PNR_OPTIONS]
                             [--nextpnr_options NEXTPNR_OPTIONS]
                             [--yosys_synth_options YOSYS_SYNTH_OPTIONS]
fusesoc run servant_0: error: unrecognized arguments: --firmware=/sw/blinky.hex