### PR TITLE
README: argument to use blinky example instead of hello world is true for all boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ And do not forget to add fusesoc-cores in your fusesoc lib :
  fusesoc library add --global fusesoc-cores https://github.com/fusesoc/fusesoc-cores
 ```
 
+Run with `--memfile=$SERV/sw/blinky.hex` as the last argument to run the LED blink example instead of hello world.
+
 ### TinyFPGA BX
 
 Pin A6 is used for UART output with 115200 baud rate.
@@ -99,8 +101,6 @@ Pin 9 is used for UART output with 57600 baud rate.
 
     cd $SERV/workspace
     fusesoc run --target=icebreaker servant
-
-Run with `--memfile=$SERV/sw/blinky.hex` as the last argument to run the LED blink example instead
 
 ## Other targets
 


### PR DESCRIPTION
The line about using memfile is after icebreaker. This location is ambiguous because it's not clear if it's only applicable to this board or if its a more generic information.
This PR move this line before board to be more generic.