### PR TITLE
Add Arty a7 35t support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Run the compliance tests
 
 ## Run on hardware
 
-Only supported so far is a single threaded Zephyr hello world example on the icebreaker and tinyFPGA BX boards. Some 
+Only supported so far is a single threaded Zephyr hello world example on the icebreaker tinyFPGA BX and arty A7 35T boards. Some
 packages should be installed before running it (and shoud be accessible in your PATH variable):
 - [icestorm](https://github.com/cliffordwolf/icestorm).
 - [nextpnr](https://github.com/YosysHQ/nextpnr).
@@ -101,6 +101,14 @@ Pin 9 is used for UART output with 57600 baud rate.
 
     cd $SERV/workspace
     fusesoc run --target=icebreaker servant
+
+### Arty A7 35T
+
+Pin D10 (uart_rxd_out) is used for UART output with 57600 baud rate (to use
+blinky.hex change D10 to H5 (led[4]) in data/arty_a7_35t.xdc).
+
+    cd $SERV/workspace
+    fusesoc run --target=arty_a7_35t servant
 
 ## Other targets
 

--- a/data/arty_a7_35t.xdc
+++ b/data/arty_a7_35t.xdc
@@ -1,0 +1,10 @@
+set_property -dict {PACKAGE_PIN E3  IOSTANDARD LVCMOS33 } [get_ports i_clk];
+
+set_property -dict {PACKAGE_PIN D10  IOSTANDARD LVCMOS33 } [get_ports q]
+
+#set_property -dict {PACKAGE_PIN H5  IOSTANDARD LVCMOS33 } [get_ports q]
+
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];

--- a/servant.core
+++ b/servant.core
@@ -38,6 +38,11 @@ filesets:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
       - servant/servix.v : {file_type : verilogSource}
       - data/nexys_a7.xdc : {file_type : xdc}
+  arty_a7_35t:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/arty_a7_35t.xdc : {file_type : xdc}
 targets:
   default:
     filesets : [soc]
@@ -78,6 +83,14 @@ targets:
     parameters : [memfile, memsize, frequency=32]
     tools:
       vivado: {part : xc7a100tcsg324-1}
+    toplevel : servix
+
+  arty_a7_35t:
+    default_tool: vivado
+    filesets : [mem_files, soc, arty_a7_35t]
+    parameters : [memfile, memsize, frequency=16]
+    tools:
+      vivado: {part : xc7a35ticsg324-1L}
     toplevel : servix
 
   sim:

--- a/servant.core
+++ b/servant.core
@@ -75,7 +75,7 @@ targets:
   nexys_a7:
     default_tool: vivado
     filesets : [mem_files, soc, nexys_a7]
-    parameters : [memfile, memsize]
+    parameters : [memfile, memsize, frequency=32]
     tools:
       vivado: {part : xc7a100tcsg324-1}
     toplevel : servix
@@ -109,6 +109,11 @@ parameters:
     datatype : file
     description : Preload RAM with a hex file at runtime (overrides memfile)
     paramtype : plusarg
+
+  frequency:
+    datatype    : int
+    description : PLL output frequency
+    paramtype   : vlogparam
 
   memfile:
     datatype    : file

--- a/servant/servix.v
+++ b/servant/servix.v
@@ -4,6 +4,7 @@ module servix
  input wire  i_clk,
  output wire q);
 
+   parameter frequency = 32;
    parameter memfile = "zephyr_hello.hex";
    parameter memsize = 8192;
    parameter PLL = "NONE";
@@ -11,7 +12,9 @@ module servix
    wire      wb_clk;
    wire      wb_rst;
 
-   servix_clock_gen clock_gen
+   servix_clock_gen
+     #(.frequency (frequency))
+   clock_gen
      (.i_clk (i_clk),
       .o_clk (wb_clk),
       .o_rst (wb_rst));

--- a/servant/servix_clock_gen.v
+++ b/servant/servix_clock_gen.v
@@ -4,6 +4,8 @@ module servix_clock_gen
    output wire o_clk,
    output reg  o_rst);
 
+   parameter frequency = 32;
+
    wire   clkfb;
    wire   locked;
    reg 	  locked_r;
@@ -12,7 +14,7 @@ module servix_clock_gen
      #(.BANDWIDTH("OPTIMIZED"),
        .CLKFBOUT_MULT(16),
        .CLKIN1_PERIOD(10.0), //100MHz
-       .CLKOUT0_DIVIDE(50),
+       .CLKOUT0_DIVIDE((frequency == 32) ? 50 : 100),
        .DIVCLK_DIVIDE(1),
        .STARTUP_WAIT("FALSE"))
    PLLE2_BASE_inst


### PR DESCRIPTION
This board is based on an Xilinx artix 35T with a input clock 100MHz, but for an unclear reason, the UART is not working with 32MHz PLL output frequency. This is why this PR add modification to servix_clock_gen, and servant.core, to be able to select 32 or 16 MHz frequency.
