### PR TITLE
Declare variables/nets before referenced

### DIFF
--- a/rtl/serv_alu.v
+++ b/rtl/serv_alu.v
@@ -73,6 +73,8 @@ module serv_alu
 
    reg        lt_r;
 
+   reg        eq_r;
+
    wire       lt_sign = i_cnt_done & !i_cmp_uns;
 
    wire       eq = (i_rs1 == op_b);
@@ -91,8 +93,6 @@ module serv_alu
                  (i_rd_sel[2] & result_lt_r & plus_1) |
                  (i_rd_sel[3] & result_bool);
 
-
-   reg 	eq_r;
 
    always @(posedge clk) begin
       add_cy_r <= i_en & add_cy;

--- a/rtl/serv_decode.v
+++ b/rtl/serv_decode.v
@@ -180,6 +180,13 @@ module serv_decode
    reg [4:0]  imm24_20;
    reg [4:0]  imm11_7;
 
+   wire [1:0] m2;
+   //True for OP-IMM, LOAD, STORE, JALR
+   //False for LUI, AUIPC, JAL
+   assign m2[0] = (opcode[1:0] == 2'b00) | (opcode[2:1] == 2'b00);
+   assign m2[1] = opcode[4] & !opcode[0];
+   wire m3 = opcode[4];
+
    assign o_alu_rd_sel[0] = (funct3 == 3'b000); // Add/sub
    assign o_alu_rd_sel[1] = (funct3[1:0] == 2'b01); //Shift
    assign o_alu_rd_sel[2] = (funct3[2:1] == 2'b01); //SLT*
@@ -219,14 +226,6 @@ module serv_decode
    //True for S (STORE) or B (BRANCH) type instructions
    //False for J type instructions
    wire m1 = opcode[3:0] == 4'b1000;
-
-   wire [1:0] m2;
-   assign m2[1] = opcode[4] & !opcode[0];
-
-   //True for OP-IMM, LOAD, STORE, JALR
-   //False for LUI, AUIPC, JAL
-   assign m2[0] = (opcode[1:0] == 2'b00) | (opcode[2:1] == 2'b00);
-   wire m3 = opcode[4];
 
    assign o_imm = i_cnt_done ? signbit : m1 ? imm11_7[0] : imm24_20[0];
 


### PR DESCRIPTION
Both `rtl/serv_alu.v` and `rtl/serv_decode.v` references to wires/regs before they are declared.
* `eq_r` is used in `serv_alu.v` before declared.
* Both `m2` and `m3` are used in `serv_decode.v` before declared.

As a side note, I've tried to run the simulation test, and I saw one thing, the command does not run inside `workspace` but in `$SERV` instead.

Here is the result after the modifications proposed here:
`INFO: Running
INFO: Running simulation
Loading RAM from /home/diego/serv/sw/zephyr_hello.hex
***** Booting Zephyr OS zephyr-v1.14.1-4-gc7c2d62513fe *****

Hello World! service
`

Seems that Verilator is not catching all linter problems, I saw this two just by looking the source code, but there are few more that Verilator is not catching.
