### PR TITLE
Add compatibility with Xilinx ISE

### DIFF
--- a/rtl/serv_rf_ram_if.v
+++ b/rtl/serv_rf_ram_if.v
@@ -2,7 +2,8 @@
 module serv_rf_ram_if
   #(parameter width=8,
     parameter csr_regs=4,
-    parameter depth=32*(32+csr_regs)/width)
+    parameter depth=32*(32+csr_regs)/width,
+    parameter l2w = $clog2(width))
   (
    //SERV side
    input wire 				i_clk,
@@ -26,8 +27,6 @@ module serv_rf_ram_if
    output wire 				o_wen,
    output wire [$clog2(depth)-1:0] 	o_raddr,
    input wire [width-1:0] 		i_rdata);
-
-   localparam l2w = $clog2(width);
 
    reg 				   rgnt;
    assign o_ready = rgnt | i_wreq;

--- a/rtl/serv_rf_top.v
+++ b/rtl/serv_rf_top.v
@@ -3,7 +3,8 @@
 module serv_rf_top
   #(parameter RESET_PC = 32'd0,
     parameter WITH_CSR = 1,
-    parameter RF_WIDTH = 2)
+    parameter RF_WIDTH = 2,
+	parameter RF_L2D   = $clog2((32+(WITH_CSR*4))*32/RF_WIDTH))
   (
    input wire 	      clk,
    input wire 	      i_rst,
@@ -44,7 +45,6 @@ module serv_rf_top
    input wire 	      i_dbus_ack);
 
    localparam CSR_REGS = WITH_CSR*4;
-   localparam RF_L2D = $clog2((32+CSR_REGS)*32/RF_WIDTH);
 
    wire 	      rf_wreq;
    wire 	      rf_rreq;

--- a/servant/servant_ram.v
+++ b/servant/servant_ram.v
@@ -32,7 +32,9 @@ module servant_ram
 
    initial
      if(|memfile) begin
+`ifndef ISE
 	$display("Preloading %m from %s", memfile);
+`endif
 	$readmemh(memfile, mem);
      end
 


### PR DESCRIPTION
This PR add some workaround due to ISE limitations/bugs:
- Add `ifndef ISE to disable not supported $display
- move use to $clog2 with parameter affectation instead of localparam to bypass a bug.