### PR TITLE
Update alhambra board

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ blinky.hex change A10 to V16 (led[0]) in data/pipistrello.ucf).
 
 ### Alhambra II
 
-Pin 61 is used for UART output with 38400 baud rate (note that it works with non-standard 43200 value too). This pin is connected to a FT2232H chip in board, that manages the communications between the FPGA and the computer.
+Pin 61 is used for UART output with 115200 baud rate. This pin is connected to a FT2232H chip in board, that manages the communications between the FPGA and the computer.
 
     cd $SERV/workspace
     fusesoc run --target=alhambra servant

--- a/servant.core
+++ b/servant.core
@@ -127,7 +127,7 @@ targets:
         speed   : -2
     toplevel : servant_lx9
 
-    
+
   tinyfpga_bx:
     default_tool : icestorm
     filesets : [mem_files, soc, service, tinyfpga_bx]
@@ -147,7 +147,7 @@ targets:
     parameters : [memfile, memsize, PLL=ICE40_CORE]
     tools:
       icestorm:
-        nextpnr_options : [--hx8k, --package, tq144:4k, --freq, 16]
+        nextpnr_options : [--hx8k, --package, "tq144:4k", --freq, 16]
         pnr: next
     toplevel : service
 
@@ -318,4 +318,4 @@ generate:
     generator: icepll
     parameters:
       freq_in  : 12
-      freq_out : 16
+      freq_out : 32

--- a/servant.core
+++ b/servant.core
@@ -147,7 +147,7 @@ targets:
     parameters : [memfile, memsize, PLL=ICE40_CORE]
     tools:
       icestorm:
-        nextpnr_options : [--hx8k, --package, "tq144:4k", --freq, 16]
+        nextpnr_options : [--hx8k, --package, "tq144:4k", --freq, 32]
         pnr: next
     toplevel : service
 


### PR DESCRIPTION
- Add "" to nextpnr option to avoid python3 parsing error
- Update PLL out value
- Update in Readme, as now the baudrate needs to be 115200 (tested in gtkterm and minicom)