### PR TITLE
Allow mpie bit to be writeable in mstatus

### DIFF
--- a/rtl/serv_csr.v
+++ b/rtl/serv_csr.v
@@ -71,10 +71,13 @@ module serv_csr
    always @(posedge i_clk) begin
       /*
        Note: To save resources mstatus_mpie (mstatus bit 7) is not
-       readable or writable from sw
+       readable from sw
        */
       if (i_mstatus_en & i_cnt3)
 	mstatus_mie <= csr_in;
+
+      if (i_mstatus_en & i_cnt7)
+	mstatus_mpie <= csr_in;
 
       if (i_mie_en & i_cnt7)
 	mie_mtie <= csr_in;


### PR DESCRIPTION
This bit is currently not r/w but this means that it is not possible to change the mstatus mie state from within an exception handler. The mie bit is always set to its previous state when mret is called.  This is an issue with an RTOS where ecall may be called from a new task creation which is in a critical section.  This mean that interrupts including the system tick will not be triggered.

This functionality was tested with the code in this GitHub
gist https://gist.github.com/btashton/4aa7ed42bc81ff4716821636997d9df9