### PR TITLE
serv on iCEstick HX1K FPGA Evaluation Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Pin 61 is used for UART output with 115200 baud rate. This pin is connected to a
     fusesoc run --target=alhambra servant
     iceprog -d i:0x0403:0x6010:0 build/servant_1.0.1/alhambra-icestorm/servant_1.0.1.bin
 
+### iCEstick
+
+Pin 95 is used as the GPIO output which is connected to the board's green LED. Due to this board's limited Embedded BRAM, programs with a maximum of 7168 bytes can be loaded. The default program for this board is blinky.hex.
+
+    cd $SERV/workspace
+    fusesoc run --target=icestick servant
+    iceprog build/servant_1.0.2/icestick-icestorm/servant_1.0.2.bin
+
 ## Other targets
 
 The above targets are run on the servant SoC, but there are some targets defined for the CPU itself. Verilator can be run in lint mode to check for design problems by running

--- a/data/icestick.pcf
+++ b/data/icestick.pcf
@@ -1,8 +1,8 @@
-# 12 MHz clock
+# 12 MHz clock input
 set_io i_clk 	21
 
 # Onboard LED (Green)
-#set_io q 			95
+set_io q 			95
 
 # UART TX
-set_io q			62
+#set_io q			62

--- a/data/icestick.pcf
+++ b/data/icestick.pcf
@@ -1,0 +1,8 @@
+# 12 MHz clock
+set_io i_clk 	21
+
+# Onboard LED (Green)
+#set_io q 			95
+
+# UART TX
+set_io q			62

--- a/servant.core
+++ b/servant.core
@@ -46,6 +46,7 @@ filesets:
   tinyfpga_bx: {files: [data/tinyfpga_bx.pcf : {file_type : PCF}]}
   icebreaker : {files: [data/icebreaker.pcf  : {file_type : PCF}]}
   alhambra   : {files: [data/alhambra.pcf : {file_type : PCF}]}
+  icestick : {files: [data/icestick.pcf  : {file_type : PCF}]}
 
   lx9_microboard:
     files:
@@ -131,7 +132,6 @@ targets:
         package : csg324
         speed   : -2
     toplevel : servant_lx9
-
 
   tinyfpga_bx:
     default_tool : icestorm
@@ -261,6 +261,17 @@ targets:
       vivado: {part : xczu7ev-ffvc1156-2-e}
     toplevel : servus
 
+  icestick:
+    default_tool : icestorm
+    filesets : [mem_files, soc, service, icestick]
+    generate: [icestick_pll]
+    parameters : [memfile=blinky.hex, memsize=7168, PLL=ICE40_CORE]
+    tools:
+      icestorm:
+        nextpnr_options : [--hx1k, --package, tq144, --freq, 32]
+        pnr: next
+    toplevel : service
+
 parameters:
   PLL:
     datatype : str
@@ -330,6 +341,12 @@ generate:
       freq_out : 32
 
   alhambra_pll:
+    generator: icepll
+    parameters:
+      freq_in  : 12
+      freq_out : 32
+
+  icestick_pll:
     generator: icepll
     parameters:
       freq_in  : 12


### PR DESCRIPTION
I tested out serv on Lattice iCEstick Evaluation Board with HX1K FPGA. I was only able to test the blinky program since HX1K has 16 x 4kb (64kb) RAM and the register file uses about 8kb which leaves 56kb (7kB - 7168 bytes) of RAM for the program. I added appropriate fusesoc parameters so that iCEstick builds pick up blinky.hex as default with 7168-byte memsize.

I encountered one issue though which has something to do with how the unused IO is configured on HX1K and the board design. Its documented here: [iCEstick unused LED Pull-up Issue](https://github.com/soumilheble/serv/issues/1).

Let me know if this platform is worthy to be pulled into serv master repo.

Thanks