### PR TITLE
Add target: Cmod A7 35T

### DIFF
--- a/data/cmod_a7_35t.xdc
+++ b/data/cmod_a7_35t.xdc
@@ -1,0 +1,14 @@
+## 12 MHz Clock Signal
+set_property -dict { PACKAGE_PIN L17   IOSTANDARD LVCMOS33 } [get_ports { i_clk }]; #IO_L12P_T1_MRCC_14 Sch=gclk
+create_clock -add -name sys_clk_pin -period 83.33 -waveform {0 41.66} [get_ports { i_clk }];
+
+## LEDs
+set_property -dict { PACKAGE_PIN A17   IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L12N_T1_MRCC_16 Sch=led[1]
+#set_property -dict { PACKAGE_PIN C16   IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L13P_T2_MRCC_16 Sch=led[2]
+
+## UART
+#set_property -dict { PACKAGE_PIN J18   IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L7N_T1_D10_14 Sch=uart_rxd_out
+#set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports { q  }]; #IO_L7P_T1_D09_14 Sch=uart_txd_in
+
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]

--- a/servant.core
+++ b/servant.core
@@ -67,6 +67,13 @@ filesets:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
       - servant/servix.v : {file_type : verilogSource}
       - data/nexys_a7.xdc : {file_type : xdc}
+
+  cmod_a7_35t:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/cmod_a7_35t.xdc : {file_type : xdc}
+
   arty_a7_35t:
     files:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
@@ -206,6 +213,14 @@ targets:
     parameters : [memfile, memsize, frequency=32]
     tools:
       vivado: {part : xc7a100tcsg324-1}
+    toplevel : servix
+
+  cmod_a7_35t:
+    default_tool: vivado
+    filesets : [mem_files, soc, cmod_a7_35t]
+    parameters : [memfile=blinky.hex, memsize, frequency=12]
+    tools:
+      vivado: {part : xc7a35tcpg236-1}
     toplevel : servix
 
   arty_a7_35t:

--- a/servant.core
+++ b/servant.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::servant:1.0.2
+name : ::servant:1.1.0
 
 filesets:
   service:

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -1,7 +1,9 @@
+TOOLCHAIN_PREFIX=riscv64-unknown-elf-
+
 %.elf: %.S link.ld
-	riscv64-unknown-elf-gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -o$@ $<
+	$(TOOLCHAIN_PREFIX)gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -o$@ $<
 %.bin: %.elf
-	riscv64-unknown-elf-objcopy -O binary $< $@
+	$(TOOLCHAIN_PREFIX)objcopy -O binary $< $@
 %.hex: %.bin
 	python3 makehex.py $< 2048 > $@
 


### PR DESCRIPTION
Hello,
I have a Cmod A7 35T and the blinky example worked just fine. I haven't yet tried the UART example, but I will be doing that in a moment. Great work!

Part: https://reference.digilentinc.com/reference/programmable-logic/cmod-a7/start

I am not sure about the versioning convention here, so I have separated it into its own commit 152be57.

Why 3b4447c? It is not related to the target I am adding.
I understand that https://github.com/riscv/riscv-gnu-toolchain#installation-linux-multilib builds the binary `riscv64-unknown-linux-gnu-` that works for both 32- and 64-bits. But that's not always the prefix for 32-bits. For instance, I have a 32-bits binary built according to https://github.com/riscv/riscv-gnu-toolchain#installation-linux.

This is the feature added by that extra commit:
```
make blinky.hex TOOLCHAIN_PREFIX=riscv32-unknown-elf-
```