### PR TITLE
Whitespace fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The FuseSoC standard library already contain a version of SERV, but if we want t
 
 `fusesoc library add serv https://github.com/olofk/serv`
 
-The SERV repo will now be available in $WORKSPACE/fusesoc_libraries/serv. To save some typing, we will refer to that directory as `$SERV`. 
+The SERV repo will now be available in $WORKSPACE/fusesoc_libraries/serv. To save some typing, we will refer to that directory as `$SERV`.
 
 We are now ready to do our first exercises with SERV
 
@@ -39,9 +39,9 @@ If everything worked, the output should look like
 
     INFO: Preparing ::serv:1.0.2
     INFO: Setting up project
-    
+
     INFO: Building simulation model
-    verilator -f serv_1.0.2.vc 
+    verilator -f serv_1.0.2.vc
     INFO: Running
 
 ## Running pre-built test software
@@ -152,7 +152,7 @@ FPGA Pin W18 (Pin 3 P8 connector)  is used for UART output with 57600 baud rate.
 
 ### SoCKit development kit
 
-FPGA Pin F14 (HSTC GPIO addon connector J2, pin 2) is used for UART output with 57600 baud rate. 
+FPGA Pin F14 (HSTC GPIO addon connector J2, pin 2) is used for UART output with 57600 baud rate.
 
     fusesoc run --target=sockit servant
 

--- a/bench/servant_sim.v
+++ b/bench/servant_sim.v
@@ -11,8 +11,8 @@ module servant_sim
    reg [1023:0] firmware_file;
    initial
      if ($value$plusargs("firmware=%s", firmware_file)) begin
-	$display("Loading RAM from %0s", firmware_file);
-	$readmemh(firmware_file, dut.ram.mem);
+        $display("Loading RAM from %0s", firmware_file);
+        $readmemh(firmware_file, dut.ram.mem);
      end
 
    servant

--- a/bench/uart_decoder.v
+++ b/bench/uart_decoder.v
@@ -11,7 +11,7 @@ module uart_decoder
       @(negedge rx);
       #(T/2) ch = 0;
       for (i=0;i<8;i=i+1)
-	#T ch[i] = rx;
+        #T ch[i] = rx;
       $write("%c",ch);
       $fflush;
    end

--- a/rtl/serv_alu.v
+++ b/rtl/serv_alu.v
@@ -1,29 +1,29 @@
 `default_nettype none
 module serv_alu
   (
-   input wire 	    clk,
+   input wire       clk,
    //State
-   input wire 	    i_en,
-   input wire 	    i_cnt0,
-   output wire 	    o_cmp,
+   input wire       i_en,
+   input wire       i_cnt0,
+   output wire      o_cmp,
    //Control
-   input wire 	    i_sub,
+   input wire       i_sub,
    input wire [1:0] i_bool_op,
-   input wire 	    i_cmp_eq,
-   input wire 	    i_cmp_sig,
+   input wire       i_cmp_eq,
+   input wire       i_cmp_sig,
    input wire [2:0] i_rd_sel,
    //Data
-   input wire 	    i_rs1,
-   input wire 	    i_op_b,
-   input wire 	    i_buf,
-   output wire 	    o_rd);
+   input wire       i_rs1,
+   input wire       i_op_b,
+   input wire       i_buf,
+   output wire      o_rd);
 
    wire        result_add;
 
-   reg 	       cmp_r;
+   reg         cmp_r;
 
    wire        add_cy;
-   reg 	       add_cy_r;
+   reg         add_cy_r;
 
    //Sign-extended operands
    wire rs1_sx  = i_rs1 & i_cmp_sig;
@@ -62,7 +62,7 @@ module serv_alu
       add_cy_r <= i_en ? add_cy : i_sub;
 
       if (i_en)
-	cmp_r <= o_cmp;
+        cmp_r <= o_cmp;
    end
 
 endmodule

--- a/rtl/serv_bufreg.v
+++ b/rtl/serv_bufreg.v
@@ -1,29 +1,29 @@
 module serv_bufreg
   (
-   input wire 	      i_clk,
+   input wire         i_clk,
    //State
-   input wire 	      i_cnt0,
-   input wire 	      i_cnt1,
-   input wire 	      i_en,
-   input wire 	      i_init,
+   input wire         i_cnt0,
+   input wire         i_cnt1,
+   input wire         i_en,
+   input wire         i_init,
    output reg [1:0]   o_lsb,
    //Control
-   input wire 	      i_rs1_en,
-   input wire 	      i_imm_en,
-   input wire 	      i_clr_lsb,
-   input wire 	      i_sh_signed, 
+   input wire         i_rs1_en,
+   input wire         i_imm_en,
+   input wire         i_clr_lsb,
+   input wire         i_sh_signed,
    //Data
-   input wire 	      i_rs1,
-   input wire 	      i_imm,
-   output wire 	      o_q,
+   input wire         i_rs1,
+   input wire         i_imm,
+   output wire        o_q,
    //External
    output wire [31:0] o_dbus_adr);
 
-   wire 	      c, q;
-   reg 		      c_r;
-   reg [31:2] 	      data;
+   wire               c, q;
+   reg                c_r;
+   reg [31:2]         data;
 
-   wire 	      clr_lsb = i_cnt0 & i_clr_lsb;
+   wire               clr_lsb = i_cnt0 & i_clr_lsb;
 
    assign {c,q} = {1'b0,(i_rs1 & i_rs1_en)} + {1'b0,(i_imm & i_imm_en & !clr_lsb)} + c_r;
 
@@ -32,10 +32,10 @@ module serv_bufreg
       c_r <= c & i_en;
 
       if (i_en)
-	data <= {i_init ? q : (data[31] & i_sh_signed), data[31:3]};
+        data <= {i_init ? q : (data[31] & i_sh_signed), data[31:3]};
 
       if (i_init ? (i_cnt0 | i_cnt1) : i_en)
-	o_lsb <= {i_init ? q : data[2],o_lsb[1]};
+        o_lsb <= {i_init ? q : data[2],o_lsb[1]};
 
    end
 

--- a/rtl/serv_csr.v
+++ b/rtl/serv_csr.v
@@ -1,34 +1,34 @@
 `default_nettype none
 module serv_csr
   (
-   input wire 	    i_clk,
+   input wire       i_clk,
    //State
-   input wire 	    i_init,
-   input wire 	    i_en,
-   input wire 	    i_cnt0to3,
-   input wire 	    i_cnt3,
-   input wire 	    i_cnt7,
-   input wire 	    i_cnt_done,
-   input wire 	    i_mem_op,
-   input wire 	    i_mtip,
-   input wire 	    i_trap,
-   output reg 	    o_new_irq,
+   input wire       i_init,
+   input wire       i_en,
+   input wire       i_cnt0to3,
+   input wire       i_cnt3,
+   input wire       i_cnt7,
+   input wire       i_cnt_done,
+   input wire       i_mem_op,
+   input wire       i_mtip,
+   input wire       i_trap,
+   output reg       o_new_irq,
    //Control
-   input wire 	    i_e_op,
-   input wire 	    i_ebreak,
-   input wire 	    i_mem_cmd,
-   input wire 	    i_mstatus_en,
-   input wire 	    i_mie_en,
-   input wire 	    i_mcause_en,
+   input wire       i_e_op,
+   input wire       i_ebreak,
+   input wire       i_mem_cmd,
+   input wire       i_mstatus_en,
+   input wire       i_mie_en,
+   input wire       i_mcause_en,
    input wire [1:0] i_csr_source,
-   input wire 	    i_mret,
-   input wire 	    i_csr_d_sel,
+   input wire       i_mret,
+   input wire       i_csr_d_sel,
    //Data
-   input wire 	    i_rf_csr_out,
-   output wire 	    o_csr_in,
-   input wire 	    i_csr_imm,
-   input wire 	    i_rs1,
-   output wire 	    o_q);
+   input wire       i_rf_csr_out,
+   output wire      o_csr_in,
+   input wire       i_csr_imm,
+   input wire       i_rs1,
+   output wire      o_q);
 
    localparam [1:0]
      CSR_SOURCE_CSR = 2'b00,
@@ -36,49 +36,49 @@ module serv_csr
      CSR_SOURCE_SET = 2'b10,
      CSR_SOURCE_CLR = 2'b11;
 
-   reg 		    mstatus_mie;
-   reg 		    mstatus_mpie;
-   reg 		    mie_mtie;
+   reg              mstatus_mie;
+   reg              mstatus_mpie;
+   reg              mie_mtie;
 
-   reg 		mcause31;
-   reg [3:0] 	mcause3_0;
-   wire 	mcause;
+   reg          mcause31;
+   reg [3:0]    mcause3_0;
+   wire         mcause;
 
-   wire 	csr_in;
-   wire 	csr_out;
+   wire         csr_in;
+   wire         csr_out;
 
-   reg 		timer_irq_r;
+   reg          timer_irq_r;
 
-   wire 	d = i_csr_d_sel ? i_csr_imm : i_rs1;
+   wire         d = i_csr_d_sel ? i_csr_imm : i_rs1;
 
    assign csr_in = (i_csr_source == CSR_SOURCE_EXT) ? d :
-		   (i_csr_source == CSR_SOURCE_SET) ? csr_out | d :
-		   (i_csr_source == CSR_SOURCE_CLR) ? csr_out & ~d :
-		   (i_csr_source == CSR_SOURCE_CSR) ? csr_out :
-		   1'bx;
+                   (i_csr_source == CSR_SOURCE_SET) ? csr_out | d :
+                   (i_csr_source == CSR_SOURCE_CLR) ? csr_out & ~d :
+                   (i_csr_source == CSR_SOURCE_CSR) ? csr_out :
+                   1'bx;
 
    assign csr_out = (i_mstatus_en & mstatus_mie & i_cnt3) |
-		    i_rf_csr_out |
-		    (i_mcause_en & i_en & mcause);
+                    i_rf_csr_out |
+                    (i_mcause_en & i_en & mcause);
 
    assign o_q = csr_out;
 
-   wire 	timer_irq = i_mtip & mstatus_mie & mie_mtie;
+   wire         timer_irq = i_mtip & mstatus_mie & mie_mtie;
 
    assign mcause = i_cnt0to3 ? mcause3_0[0] : //[3:0]
-		   i_cnt_done ? mcause31 //[31]
-		   : 1'b0;
+                   i_cnt_done ? mcause31 //[31]
+                   : 1'b0;
 
    assign o_csr_in = csr_in;
 
    always @(posedge i_clk) begin
       if (!i_init & i_cnt_done) begin
-	 timer_irq_r <= timer_irq;
-	 o_new_irq   <= timer_irq & !timer_irq_r;
+         timer_irq_r <= timer_irq;
+         o_new_irq   <= timer_irq & !timer_irq_r;
       end
-	 
+
       if (i_mie_en & i_cnt7)
-	mie_mtie <= csr_in;
+        mie_mtie <= csr_in;
 
       /*
        The mie bit in mstatus gets updated under three conditions
@@ -91,14 +91,14 @@ module serv_csr
        These conditions are all mutually exclusibe
        */
       if ((i_trap & i_cnt_done) | i_mstatus_en & i_cnt3 | i_mret)
-	mstatus_mie <= !i_trap & (i_mret ?  mstatus_mpie : csr_in);
+        mstatus_mie <= !i_trap & (i_mret ?  mstatus_mpie : csr_in);
 
       /*
        Note: To save resources mstatus_mpie (mstatus bit 7) is not
        readable or writable from sw
        */
       if (i_trap & i_cnt_done)
-	mstatus_mpie <= mstatus_mie;
+        mstatus_mpie <= mstatus_mie;
 
       /*
        The four lowest bits in mcause hold the exception code
@@ -123,13 +123,13 @@ module serv_csr
        ctrl => 0000 (jump=0)
        */
       if (i_mcause_en & i_en & i_cnt0to3 | (i_trap & i_cnt_done)) begin
-	 mcause3_0[3] <= (i_e_op & !i_ebreak) | (!i_trap & csr_in);
-	 mcause3_0[2] <= o_new_irq | i_mem_op | (!i_trap & mcause3_0[3]);
-	 mcause3_0[1] <= o_new_irq | i_e_op | (i_mem_op & i_mem_cmd) | (!i_trap & mcause3_0[2]);
-	 mcause3_0[0] <= o_new_irq | i_e_op | (!i_trap & mcause3_0[1]);
+         mcause3_0[3] <= (i_e_op & !i_ebreak) | (!i_trap & csr_in);
+         mcause3_0[2] <= o_new_irq | i_mem_op | (!i_trap & mcause3_0[3]);
+         mcause3_0[1] <= o_new_irq | i_e_op | (i_mem_op & i_mem_cmd) | (!i_trap & mcause3_0[2]);
+         mcause3_0[0] <= o_new_irq | i_e_op | (!i_trap & mcause3_0[1]);
       end
       if (i_mcause_en & i_cnt_done | i_trap)
-	mcause31 <= i_trap ? o_new_irq : csr_in;
+        mcause31 <= i_trap ? o_new_irq : csr_in;
    end
 
 endmodule

--- a/rtl/serv_ctrl.v
+++ b/rtl/serv_ctrl.v
@@ -4,34 +4,34 @@ module serv_ctrl
     parameter RESET_PC = 32'd0,
     parameter WITH_CSR = 1)
   (
-   input wire 	     clk,
-   input wire 	     i_rst,
+   input wire        clk,
+   input wire        i_rst,
    //State
-   input wire 	     i_pc_en,
-   input wire 	     i_cnt12to31,
-   input wire 	     i_cnt0,
-   input wire 	     i_cnt2,
+   input wire        i_pc_en,
+   input wire        i_cnt12to31,
+   input wire        i_cnt0,
+   input wire        i_cnt2,
    //Control
-   input wire 	     i_jump,
-   input wire 	     i_jal_or_jalr,
-   input wire 	     i_utype,
-   input wire 	     i_pc_rel,
-   input wire 	     i_trap,
+   input wire        i_jump,
+   input wire        i_jal_or_jalr,
+   input wire        i_utype,
+   input wire        i_pc_rel,
+   input wire        i_trap,
    //Data
-   input wire 	     i_imm,
-   input wire 	     i_buf,
-   input wire 	     i_csr_pc,
-   output wire 	     o_rd,
-   output wire 	     o_bad_pc,
+   input wire        i_imm,
+   input wire        i_buf,
+   input wire        i_csr_pc,
+   output wire       o_rd,
+   output wire       o_bad_pc,
    //External
    output reg [31:0] o_ibus_adr);
 
    wire       pc_plus_4;
    wire       pc_plus_4_cy;
-   reg 	      pc_plus_4_cy_r;
+   reg        pc_plus_4_cy_r;
    wire       pc_plus_offset;
    wire       pc_plus_offset_cy;
-   reg 	      pc_plus_offset_cy_r;
+   reg        pc_plus_offset_cy_r;
    wire       pc_plus_offset_aligned;
    wire       plus_4;
 
@@ -50,9 +50,9 @@ module serv_ctrl
 
    generate
       if (WITH_CSR)
-	assign new_pc = i_trap ? (i_csr_pc & !i_cnt0) : i_jump ? pc_plus_offset_aligned : pc_plus_4;
+        assign new_pc = i_trap ? (i_csr_pc & !i_cnt0) : i_jump ? pc_plus_offset_aligned : pc_plus_4;
       else
-	assign new_pc = i_jump ? pc_plus_offset_aligned : pc_plus_4;
+        assign new_pc = i_jump ? pc_plus_offset_aligned : pc_plus_4;
    endgenerate
    assign o_rd  = (i_utype & pc_plus_offset_aligned) | (pc_plus_4 & i_jal_or_jalr);
 
@@ -69,11 +69,11 @@ module serv_ctrl
       pc_plus_offset_cy_r <= i_pc_en & pc_plus_offset_cy;
 
       if (RESET_STRATEGY == "NONE") begin
-	 if (i_pc_en)
-	   o_ibus_adr <= {new_pc, o_ibus_adr[31:1]};
+         if (i_pc_en)
+           o_ibus_adr <= {new_pc, o_ibus_adr[31:1]};
       end else begin
-	 if (i_pc_en | i_rst)
-	   o_ibus_adr <= i_rst ? RESET_PC : {new_pc, o_ibus_adr[31:1]};
+         if (i_pc_en | i_rst)
+           o_ibus_adr <= i_rst ? RESET_PC : {new_pc, o_ibus_adr[31:1]};
       end
    end
 endmodule

--- a/rtl/serv_decode.v
+++ b/rtl/serv_decode.v
@@ -1,64 +1,64 @@
 `default_nettype none
 module serv_decode
   (
-   input wire 	     clk,
+   input wire        clk,
    //Input
    input wire [31:2] i_wb_rdt,
-   input wire 	     i_wb_en,
+   input wire        i_wb_en,
    //To state
-   output wire 	     o_sh_right,
-   output wire 	     o_bne_or_bge,
-   output wire 	     o_cond_branch,
-   output wire 	     o_e_op,
-   output wire 	     o_ebreak,
-   output wire 	     o_branch_op,
-   output wire 	     o_mem_op,
-   output wire 	     o_shift_op,
-   output wire 	     o_slt_op,
-   output wire 	     o_rd_op,
+   output wire       o_sh_right,
+   output wire       o_bne_or_bge,
+   output wire       o_cond_branch,
+   output wire       o_e_op,
+   output wire       o_ebreak,
+   output wire       o_branch_op,
+   output wire       o_mem_op,
+   output wire       o_shift_op,
+   output wire       o_slt_op,
+   output wire       o_rd_op,
    //To bufreg
-   output wire 	     o_bufreg_rs1_en,
-   output wire 	     o_bufreg_imm_en,
-   output wire 	     o_bufreg_clr_lsb,
-   output wire 	     o_bufreg_sh_signed,
+   output wire       o_bufreg_rs1_en,
+   output wire       o_bufreg_imm_en,
+   output wire       o_bufreg_clr_lsb,
+   output wire       o_bufreg_sh_signed,
    //To ctrl
-   output wire 	     o_ctrl_jal_or_jalr,
-   output wire 	     o_ctrl_utype,
-   output wire 	     o_ctrl_pc_rel,
-   output wire 	     o_ctrl_mret,
+   output wire       o_ctrl_jal_or_jalr,
+   output wire       o_ctrl_utype,
+   output wire       o_ctrl_pc_rel,
+   output wire       o_ctrl_mret,
    //To alu
-   output wire 	     o_alu_sub,
+   output wire       o_alu_sub,
    output wire [1:0] o_alu_bool_op,
-   output wire 	     o_alu_cmp_eq,
-   output wire 	     o_alu_cmp_sig,
+   output wire       o_alu_cmp_eq,
+   output wire       o_alu_cmp_sig,
    output wire [2:0] o_alu_rd_sel,
    //To mem IF
-   output wire 	     o_mem_signed,
-   output wire 	     o_mem_word,
-   output wire 	     o_mem_half,
-   output wire 	     o_mem_cmd,
+   output wire       o_mem_signed,
+   output wire       o_mem_word,
+   output wire       o_mem_half,
+   output wire       o_mem_cmd,
    //To CSR
-   output wire 	     o_csr_en,
+   output wire       o_csr_en,
    output wire [1:0] o_csr_addr,
-   output wire 	     o_csr_mstatus_en,
-   output wire 	     o_csr_mie_en,
-   output wire 	     o_csr_mcause_en,
+   output wire       o_csr_mstatus_en,
+   output wire       o_csr_mie_en,
+   output wire       o_csr_mcause_en,
    output wire [1:0] o_csr_source,
-   output wire 	     o_csr_d_sel,
-   output wire 	     o_csr_imm_en,
+   output wire       o_csr_d_sel,
+   output wire       o_csr_imm_en,
    //To top
    output wire [3:0] o_immdec_ctrl,
    output wire [3:0] o_immdec_en,
-   output wire 	     o_op_b_source,
-   output wire 	     o_rd_csr_en,
-   output wire 	     o_rd_alu_en);
+   output wire       o_op_b_source,
+   output wire       o_rd_csr_en,
+   output wire       o_rd_alu_en);
 
    reg [4:0] opcode;
    reg [2:0] funct3;
-   reg 	      op20;
-   reg 	      op21;
-   reg 	      op22;
-   reg 	      op26;
+   reg        op20;
+   reg        op21;
+   reg        op22;
+   reg        op26;
 
    reg       imm30;
 
@@ -92,14 +92,14 @@ module serv_decode
    //True for jal, b* auipc
    //False for jalr, lui
    assign o_ctrl_pc_rel = (opcode[2:0] == 3'b000) |
-			  (opcode[1:0] == 2'b11) |
-			  (opcode[4:3] == 2'b00);
+                          (opcode[1:0] == 2'b11) |
+                          (opcode[4:3] == 2'b00);
    //Write to RD
    //True for OP-IMM, AUIPC, OP, LUI, SYSTEM, JALR, JAL, LOAD
    //False for STORE, BRANCH, MISC-MEM
    assign o_rd_op = (opcode[2] |
-		     (!opcode[2] & opcode[4] & opcode[0]) |
-		     (!opcode[2] & !opcode[3] & !opcode[0]));
+                     (!opcode[2] & opcode[4] & opcode[0]) |
+                     (!opcode[2] & !opcode[3] & !opcode[0]));
 
    //
    //funct3
@@ -107,7 +107,7 @@ module serv_decode
 
    assign o_sh_right   = funct3[2];
    assign o_bne_or_bge = funct3[0];
-   
+
    //
    // opcode & funct3
    //
@@ -150,10 +150,10 @@ module serv_decode
     Bits 26, 22, 21 and 20 are enough to uniquely identify the eight supported CSR regs
     mtvec, mscratch, mepc and mtval are stored externally (normally in the RF) and are
     treated differently from mstatus, mie and mcause which are stored in serv_csr.
-    
+
     The former get a 2-bit address as seen below while the latter get a
     one-hot enable signal each.
-    
+
     Hex|2 222|Reg     |csr
     adr|6 210|name    |addr
     ---|-----|--------|----
@@ -164,7 +164,7 @@ module serv_decode
     341|1_001|mepc    | 10
     342|1_010|mcause  | xx
     343|1_011|mtval   | 11
-    
+
     */
 
    //true  for mtvec,mscratch,mepc and mtval
@@ -198,7 +198,7 @@ module serv_decode
    //False for J type instructions
    assign o_immdec_ctrl[0] = opcode[3:0] == 4'b1000;
    //True for OP-IMM, LOAD, STORE, JALR  (I S)
-   //False for LUI, AUIPC, JAL           (U J) 
+   //False for LUI, AUIPC, JAL           (U J)
    assign o_immdec_ctrl[1] = (opcode[1:0] == 2'b00) | (opcode[2:1] == 2'b00);
    assign o_immdec_ctrl[2] = opcode[4] & !opcode[0];
    assign o_immdec_ctrl[3] = opcode[4];
@@ -216,10 +216,10 @@ module serv_decode
          funct3        <= i_wb_rdt[14:12];
          imm30         <= i_wb_rdt[30];
          opcode        <= i_wb_rdt[6:2];
-	 op20 <= i_wb_rdt[20];
-	 op21 <= i_wb_rdt[21];
-	 op22 <= i_wb_rdt[22];
-	 op26 <= i_wb_rdt[26];
+         op20 <= i_wb_rdt[20];
+         op21 <= i_wb_rdt[21];
+         op22 <= i_wb_rdt[22];
+         op26 <= i_wb_rdt[26];
       end
    end
 

--- a/rtl/serv_immdec.v
+++ b/rtl/serv_immdec.v
@@ -2,28 +2,28 @@
 module serv_immdec
   #(parameter SHARED_RFADDR_IMM_REGS = 1)
   (
-   input wire 	     i_clk,
+   input wire        i_clk,
    //State
-   input wire 	     i_cnt_en,
-   input wire 	     i_cnt_done,
+   input wire        i_cnt_en,
+   input wire        i_cnt_done,
    //Control
    input wire [3:0]  i_immdec_en,
-   input wire 	     i_csr_imm_en,
+   input wire        i_csr_imm_en,
    input wire [3:0]  i_ctrl,
    output wire [4:0] o_rd_addr,
    output wire [4:0] o_rs1_addr,
    output wire [4:0] o_rs2_addr,
    //Data
-   output wire 	     o_csr_imm,
-   output wire 	     o_imm,
+   output wire       o_csr_imm,
+   output wire       o_imm,
    //External
-   input wire 	     i_wb_en,
+   input wire        i_wb_en,
    input wire [31:7] i_wb_rdt);
 
-   reg 	      signbit;
+   reg        signbit;
 
    reg [8:0]  imm19_12_20;
-   reg 	      imm7;
+   reg        imm7;
    reg [5:0]  imm30_25;
    reg [4:0]  imm24_20;
    reg [4:0]  imm11_7;
@@ -33,60 +33,60 @@ module serv_immdec
 
    generate
       if (SHARED_RFADDR_IMM_REGS) begin
-	 assign o_rs1_addr = imm19_12_20[8:4];
-	 assign o_rs2_addr = imm24_20;
-	 assign o_rd_addr  = imm11_7;
+         assign o_rs1_addr = imm19_12_20[8:4];
+         assign o_rs2_addr = imm24_20;
+         assign o_rd_addr  = imm11_7;
 
-	 always @(posedge i_clk) begin
-	    if (i_wb_en) begin
-	       /* CSR immediates are always zero-extended, hence clear the signbit */
-	       signbit     <= i_wb_rdt[31] & !i_csr_imm_en;
-	    end
-	    if (i_wb_en | (i_cnt_en & i_immdec_en[1]))
-	      imm19_12_20 <= i_wb_en ? {i_wb_rdt[19:12],i_wb_rdt[20]} : {i_ctrl[3] ? signbit : imm24_20[0], imm19_12_20[8:1]};
-	    if (i_wb_en | (i_cnt_en))
-	      imm7        <= i_wb_en ? i_wb_rdt[7]                    : signbit;
+         always @(posedge i_clk) begin
+            if (i_wb_en) begin
+               /* CSR immediates are always zero-extended, hence clear the signbit */
+               signbit     <= i_wb_rdt[31] & !i_csr_imm_en;
+            end
+            if (i_wb_en | (i_cnt_en & i_immdec_en[1]))
+              imm19_12_20 <= i_wb_en ? {i_wb_rdt[19:12],i_wb_rdt[20]} : {i_ctrl[3] ? signbit : imm24_20[0], imm19_12_20[8:1]};
+            if (i_wb_en | (i_cnt_en))
+              imm7        <= i_wb_en ? i_wb_rdt[7]                    : signbit;
 
-	    if (i_wb_en | (i_cnt_en & i_immdec_en[3]))
-	      imm30_25    <= i_wb_en ? i_wb_rdt[30:25] : {i_ctrl[2] ? imm7 : i_ctrl[1] ? signbit : imm19_12_20[0], imm30_25[5:1]};
+            if (i_wb_en | (i_cnt_en & i_immdec_en[3]))
+              imm30_25    <= i_wb_en ? i_wb_rdt[30:25] : {i_ctrl[2] ? imm7 : i_ctrl[1] ? signbit : imm19_12_20[0], imm30_25[5:1]};
 
-	    if (i_wb_en | (i_cnt_en & i_immdec_en[2]))
-	      imm24_20    <= i_wb_en ? i_wb_rdt[24:20] : {imm30_25[0], imm24_20[4:1]};
+            if (i_wb_en | (i_cnt_en & i_immdec_en[2]))
+              imm24_20    <= i_wb_en ? i_wb_rdt[24:20] : {imm30_25[0], imm24_20[4:1]};
 
-	    if (i_wb_en | (i_cnt_en & i_immdec_en[0]))
-	      imm11_7     <= i_wb_en ? i_wb_rdt[11:7] : {imm30_25[0], imm11_7[4:1]};
-	 end
+            if (i_wb_en | (i_cnt_en & i_immdec_en[0]))
+              imm11_7     <= i_wb_en ? i_wb_rdt[11:7] : {imm30_25[0], imm11_7[4:1]};
+         end
       end else begin
-	 reg [4:0]  rd_addr;
-	 reg [4:0]  rs1_addr;
-	 reg [4:0]  rs2_addr;
+         reg [4:0]  rd_addr;
+         reg [4:0]  rs1_addr;
+         reg [4:0]  rs2_addr;
 
-	 assign o_rd_addr  = rd_addr;
-	 assign o_rs1_addr = rs1_addr;
-	 assign o_rs2_addr = rs2_addr;
-	 always @(posedge i_clk) begin
-	    if (i_wb_en) begin
-	       /* CSR immediates are always zero-extended, hence clear the signbit */
-	       signbit     <= i_wb_rdt[31] & !i_csr_imm_en;
-	       imm19_12_20 <= {i_wb_rdt[19:12],i_wb_rdt[20]};
-	       imm7        <= i_wb_rdt[7];
-	       imm30_25    <= i_wb_rdt[30:25];
-	       imm24_20    <= i_wb_rdt[24:20];
-	       imm11_7     <= i_wb_rdt[11:7];
+         assign o_rd_addr  = rd_addr;
+         assign o_rs1_addr = rs1_addr;
+         assign o_rs2_addr = rs2_addr;
+         always @(posedge i_clk) begin
+            if (i_wb_en) begin
+               /* CSR immediates are always zero-extended, hence clear the signbit */
+               signbit     <= i_wb_rdt[31] & !i_csr_imm_en;
+               imm19_12_20 <= {i_wb_rdt[19:12],i_wb_rdt[20]};
+               imm7        <= i_wb_rdt[7];
+               imm30_25    <= i_wb_rdt[30:25];
+               imm24_20    <= i_wb_rdt[24:20];
+               imm11_7     <= i_wb_rdt[11:7];
 
                rd_addr  <= i_wb_rdt[11:7];
                rs1_addr <= i_wb_rdt[19:15];
                rs2_addr <= i_wb_rdt[24:20];
-	    end
-	    if (i_cnt_en) begin
-	       imm19_12_20 <= {i_ctrl[3] ? signbit : imm24_20[0], imm19_12_20[8:1]};
-	       imm7        <= signbit;
-	       imm30_25    <= {i_ctrl[2] ? imm7 : i_ctrl[1] ? signbit : imm19_12_20[0], imm30_25[5:1]};
-	       imm24_20    <= {imm30_25[0], imm24_20[4:1]};
-	       imm11_7     <= {imm30_25[0], imm11_7[4:1]};
-	    end
-	 end
+            end
+            if (i_cnt_en) begin
+               imm19_12_20 <= {i_ctrl[3] ? signbit : imm24_20[0], imm19_12_20[8:1]};
+               imm7        <= signbit;
+               imm30_25    <= {i_ctrl[2] ? imm7 : i_ctrl[1] ? signbit : imm19_12_20[0], imm30_25[5:1]};
+               imm24_20    <= {imm30_25[0], imm24_20[4:1]};
+               imm11_7     <= {imm30_25[0], imm11_7[4:1]};
+            end
+         end
       end
    endgenerate
-	 
+
 endmodule

--- a/rtl/serv_mem_if.v
+++ b/rtl/serv_mem_if.v
@@ -2,33 +2,33 @@
 module serv_mem_if
   #(parameter WITH_CSR = 1)
   (
-   input wire 	      i_clk,
+   input wire         i_clk,
    //State
-   input wire 	      i_en,
-   input wire 	      i_init,
-   input wire 	      i_cnt_done,
+   input wire         i_en,
+   input wire         i_init,
+   input wire         i_cnt_done,
    input wire [1:0]   i_bytecnt,
    input wire [1:0]   i_lsb,
-   output wire 	      o_misalign,
-   output wire 	      o_sh_done,
-   output wire 	      o_sh_done_r,
+   output wire        o_misalign,
+   output wire        o_sh_done,
+   output wire        o_sh_done_r,
    //Control
-   input wire 	      i_mem_op,
-   input wire 	      i_shift_op,
-   input wire 	      i_signed,
-   input wire 	      i_word,
-   input wire 	      i_half,
+   input wire         i_mem_op,
+   input wire         i_shift_op,
+   input wire         i_signed,
+   input wire         i_word,
+   input wire         i_half,
    //Data
-   input wire 	      i_op_b,
-   output wire 	      o_rd,
+   input wire         i_op_b,
+   output wire        o_rd,
    //External interface
    output wire [31:0] o_wb_dat,
    output wire [3:0]  o_wb_sel,
    input wire [31:0]  i_wb_rdt,
-   input wire 	      i_wb_ack);
+   input wire         i_wb_ack);
 
    reg           signbit;
-   reg [31:0] 	 dat;
+   reg [31:0]    dat;
 
    /*
     Before a store operation, the data to be written needs to be shifted into
@@ -38,25 +38,25 @@ module serv_mem_if
     clever enough so the hideous expression below is used to achieve the same
     thing in a more optimal way.
     */
-   wire 	 byte_valid =
-		 (!i_lsb[0] & !i_lsb[1])         |
-		 (!i_bytecnt[0] & !i_bytecnt[1]) |
-		 (!i_bytecnt[1] & !i_lsb[1])     |
-		 (!i_bytecnt[1] & !i_lsb[0])     |
-		 (!i_bytecnt[0] & !i_lsb[1]);
+   wire          byte_valid =
+                 (!i_lsb[0] & !i_lsb[1])         |
+                 (!i_bytecnt[0] & !i_bytecnt[1]) |
+                 (!i_bytecnt[1] & !i_lsb[1])     |
+                 (!i_bytecnt[1] & !i_lsb[0])     |
+                 (!i_bytecnt[0] & !i_lsb[1]);
 
-   wire 	 dat_en = i_shift_op | (i_en & byte_valid);
+   wire          dat_en = i_shift_op | (i_en & byte_valid);
 
-   wire 	 dat_cur =
-		 ((i_lsb == 2'd3) & dat[24]) |
-		 ((i_lsb == 2'd2) & dat[16]) |
-		 ((i_lsb == 2'd1) & dat[8]) |
-		 ((i_lsb == 2'd0) & dat[0]);
+   wire          dat_cur =
+                 ((i_lsb == 2'd3) & dat[24]) |
+                 ((i_lsb == 2'd2) & dat[16]) |
+                 ((i_lsb == 2'd1) & dat[8]) |
+                 ((i_lsb == 2'd0) & dat[0]);
 
    wire dat_valid =
-	i_word |
-	(i_bytecnt == 2'b00) |
-	(i_half & !i_bytecnt[1]);
+        i_word |
+        (i_bytecnt == 2'b00) |
+        (i_half & !i_bytecnt[1]);
 
    assign o_rd = i_mem_op & (dat_valid ? dat_cur : signbit & i_signed);
 
@@ -80,17 +80,17 @@ module serv_mem_if
             the requested number of shifts have been performed
     */
    wire [5:0] dat_shamt = (i_shift_op & !i_init) ?
-	      //Down counter mode
-	      dat[5:0]-1 :
-	      //Shift reg mode with optional clearing of bit 5
-	      {dat[6] & !(i_shift_op & i_cnt_done),dat[5:1]};
+              //Down counter mode
+              dat[5:0]-1 :
+              //Shift reg mode with optional clearing of bit 5
+              {dat[6] & !(i_shift_op & i_cnt_done),dat[5:1]};
 
    assign o_sh_done = dat_shamt[5];
    assign o_sh_done_r = dat[5];
 
    always @(posedge i_clk) begin
       if (dat_en | i_wb_ack)
-	dat <= i_wb_ack ? i_wb_rdt : {i_op_b, dat[31:7], dat_shamt};
+        dat <= i_wb_ack ? i_wb_rdt : {i_op_b, dat[31:7], dat_shamt};
 
       if (dat_valid)
         signbit <= dat_cur;

--- a/rtl/serv_rf_if.v
+++ b/rtl/serv_rf_if.v
@@ -2,66 +2,66 @@
 module serv_rf_if
   #(parameter WITH_CSR = 1)
   (//RF Interface
-   input wire 		      i_cnt_en,
+   input wire                 i_cnt_en,
    output wire [4+WITH_CSR:0] o_wreg0,
    output wire [4+WITH_CSR:0] o_wreg1,
-   output wire 		      o_wen0,
-   output wire 		      o_wen1,
-   output wire 		      o_wdata0,
-   output wire 		      o_wdata1,
+   output wire                o_wen0,
+   output wire                o_wen1,
+   output wire                o_wdata0,
+   output wire                o_wdata1,
    output wire [4+WITH_CSR:0] o_rreg0,
    output wire [4+WITH_CSR:0] o_rreg1,
-   input wire 		      i_rdata0,
-   input wire 		      i_rdata1,
+   input wire                 i_rdata0,
+   input wire                 i_rdata1,
 
    //Trap interface
-   input wire 		      i_trap,
-   input wire 		      i_mret,
-   input wire 		      i_mepc,
-   input wire 		      i_mem_op,
-   input wire 		      i_bufreg_q,
-   input wire 		      i_bad_pc,
-   output wire 		      o_csr_pc,
+   input wire                 i_trap,
+   input wire                 i_mret,
+   input wire                 i_mepc,
+   input wire                 i_mem_op,
+   input wire                 i_bufreg_q,
+   input wire                 i_bad_pc,
+   output wire                o_csr_pc,
    //CSR interface
-   input wire 		      i_csr_en,
-   input wire [1:0] 	      i_csr_addr,
-   input wire 		      i_csr,
-   output wire 		      o_csr,
+   input wire                 i_csr_en,
+   input wire [1:0]           i_csr_addr,
+   input wire                 i_csr,
+   output wire                o_csr,
    //RD write port
-   input wire 		      i_rd_wen,
-   input wire [4:0] 	      i_rd_waddr,
-   input wire 		      i_ctrl_rd,
-   input wire 		      i_alu_rd,
-   input wire 		      i_rd_alu_en,
-   input wire 		      i_csr_rd,
-   input wire 		      i_rd_csr_en,
-   input wire 		      i_mem_rd,
+   input wire                 i_rd_wen,
+   input wire [4:0]           i_rd_waddr,
+   input wire                 i_ctrl_rd,
+   input wire                 i_alu_rd,
+   input wire                 i_rd_alu_en,
+   input wire                 i_csr_rd,
+   input wire                 i_rd_csr_en,
+   input wire                 i_mem_rd,
 
    //RS1 read port
-   input wire [4:0] 	      i_rs1_raddr,
-   output wire 		      o_rs1,
+   input wire [4:0]           i_rs1_raddr,
+   output wire                o_rs1,
    //RS2 read port
-   input wire [4:0] 	      i_rs2_raddr,
-   output wire 		      o_rs2);
+   input wire [4:0]           i_rs2_raddr,
+   output wire                o_rs2);
 
 
    /*
     ********** Write side ***********
     */
 
-   wire 	     rd_wen = i_rd_wen & (|i_rd_waddr);
+   wire              rd_wen = i_rd_wen & (|i_rd_waddr);
 
    generate
    if (WITH_CSR) begin
-   wire 	     rd = (i_ctrl_rd ) |
-			  (i_alu_rd & i_rd_alu_en) |
-			  (i_csr_rd & i_rd_csr_en) |
-			  (i_mem_rd);
+   wire              rd = (i_ctrl_rd ) |
+                          (i_alu_rd & i_rd_alu_en) |
+                          (i_csr_rd & i_rd_csr_en) |
+                          (i_mem_rd);
 
-   wire 	     mtval = i_mem_op ? i_bufreg_q : i_bad_pc;
+   wire              mtval = i_mem_op ? i_bufreg_q : i_bad_pc;
 
-   assign 	     o_wdata0 = i_trap ? mtval  : rd;
-   assign	     o_wdata1 = i_trap ? i_mepc : i_csr;
+   assign            o_wdata0 = i_trap ? mtval  : rd;
+   assign            o_wdata1 = i_trap ? i_mepc : i_csr;
 
    /* Port 0 handles writes to mtval during traps and rd otherwise
     * Port 1 handles writes to mepc during traps and csr accesses otherwise
@@ -110,8 +110,8 @@ module serv_rf_if
     */
    wire sel_rs2 = !(i_trap | i_mret | i_csr_en);
    assign o_rreg1 = {~sel_rs2,
-		     i_rs2_raddr[4:2] & {3{sel_rs2}},
-		     {1'b0,i_trap} | {i_mret,1'b0} | ({2{i_csr_en}} & i_csr_addr) | ({2{sel_rs2}} & i_rs2_raddr[1:0])};
+                     i_rs2_raddr[4:2] & {3{sel_rs2}},
+                     {1'b0,i_trap} | {i_mret,1'b0} | ({2{i_csr_en}} & i_csr_addr) | ({2{sel_rs2}} & i_rs2_raddr[1:0])};
 
    assign o_rs1 = i_rdata0;
    assign o_rs2 = i_rdata1;
@@ -119,12 +119,12 @@ module serv_rf_if
    assign o_csr_pc = i_rdata1;
 
    end else begin
-      wire 	     rd = (i_ctrl_rd ) |
-			  (i_alu_rd & i_rd_alu_en) |
-			  (i_mem_rd);
+      wire           rd = (i_ctrl_rd ) |
+                          (i_alu_rd & i_rd_alu_en) |
+                          (i_mem_rd);
 
-      assign 	     o_wdata0 = rd;
-      assign	     o_wdata1 = 1'b0;
+      assign         o_wdata0 = rd;
+      assign         o_wdata1 = 1'b0;
 
       assign o_wreg0 = i_rd_waddr;
       assign o_wreg1 = 5'd0;

--- a/rtl/serv_rf_ram.v
+++ b/rtl/serv_rf_ram.v
@@ -4,16 +4,16 @@ module serv_rf_ram
     parameter depth=32*(32+csr_regs)/width)
    (input wire i_clk,
     input wire [$clog2(depth)-1:0] i_waddr,
-    input wire [width-1:0] 	   i_wdata,
-    input wire 			   i_wen,
+    input wire [width-1:0]         i_wdata,
+    input wire                     i_wen,
     input wire [$clog2(depth)-1:0] i_raddr,
-    output reg [width-1:0] 	   o_rdata);
-   
-   reg [width-1:0] 		   memory [0:depth-1];
+    output reg [width-1:0]         o_rdata);
+
+   reg [width-1:0]                 memory [0:depth-1];
 
    always @(posedge i_clk) begin
       if (i_wen)
-	memory[i_waddr] <= i_wdata;
+        memory[i_waddr] <= i_wdata;
       o_rdata <= memory[i_raddr];
    end
 

--- a/rtl/serv_rf_ram_if.v
+++ b/rtl/serv_rf_ram_if.v
@@ -7,45 +7,45 @@ module serv_rf_ram_if
     parameter l2w = $clog2(width))
   (
    //SERV side
-   input wire 				i_clk,
-   input wire 				i_rst,
-   input wire 				i_wreq,
-   input wire 				i_rreq,
-   output wire 				o_ready,
+   input wire                           i_clk,
+   input wire                           i_rst,
+   input wire                           i_wreq,
+   input wire                           i_rreq,
+   output wire                          o_ready,
    input wire [$clog2(32+csr_regs)-1:0] i_wreg0,
    input wire [$clog2(32+csr_regs)-1:0] i_wreg1,
-   input wire 				i_wen0,
-   input wire 				i_wen1,
-   input wire 				i_wdata0,
-   input wire 				i_wdata1,
+   input wire                           i_wen0,
+   input wire                           i_wen1,
+   input wire                           i_wdata0,
+   input wire                           i_wdata1,
    input wire [$clog2(32+csr_regs)-1:0] i_rreg0,
    input wire [$clog2(32+csr_regs)-1:0] i_rreg1,
-   output wire 				o_rdata0,
-   output wire 				o_rdata1,
+   output wire                          o_rdata0,
+   output wire                          o_rdata1,
    //RAM side
-   output wire [$clog2(depth)-1:0] 	o_waddr,
-   output wire [width-1:0] 		o_wdata,
-   output wire 				o_wen,
-   output wire [$clog2(depth)-1:0] 	o_raddr,
-   input wire [width-1:0] 		i_rdata);
+   output wire [$clog2(depth)-1:0]      o_waddr,
+   output wire [width-1:0]              o_wdata,
+   output wire                          o_wen,
+   output wire [$clog2(depth)-1:0]      o_raddr,
+   input wire [width-1:0]               i_rdata);
 
-   reg 				   rgnt;
+   reg                             rgnt;
    assign o_ready = rgnt | i_wreq;
-   reg [4:0] 	  rcnt;
+   reg [4:0]      rcnt;
 
    /*
     ********** Write side ***********
     */
 
-   wire [4:0] 	     wcnt;
+   wire [4:0]        wcnt;
 
    reg [width-2:0]   wdata0_r;
    reg [width-1:0]   wdata1_r;
 
-   reg 		     wen0_r;
-   reg 		     wen1_r;
-   wire 	     wtrig0;
-   wire 	     wtrig1;
+   reg               wen0_r;
+   reg               wen1_r;
+   wire              wtrig0;
+   wire              wtrig1;
 
    generate if (width == 2) begin
       assign wtrig0 = ~wcnt[0];
@@ -58,9 +58,9 @@ module serv_rf_ram_if
    end
    endgenerate
 
-   assign 	     o_wdata = wtrig1 ?
-			       wdata1_r :
-			       {i_wdata0, wdata0_r};
+   assign            o_wdata = wtrig1 ?
+                               wdata1_r :
+                               {i_wdata0, wdata0_r};
 
    wire [$clog2(32+csr_regs)-1:0] wreg  = wtrig1 ? i_wreg1 : i_wreg0;
    generate if (width == 32)
@@ -92,8 +92,8 @@ module serv_rf_ram_if
     */
 
 
-   wire 	  rtrig0;
-   reg 		  rtrig1;
+   wire           rtrig0;
+   reg            rtrig1;
 
    wire [$clog2(32+csr_regs)-1:0] rreg = rtrig0 ? i_rreg1 : i_rreg0;
    generate if (width == 32)
@@ -110,13 +110,13 @@ module serv_rf_ram_if
 
    assign rtrig0 = (rcnt[l2w-1:0] == 1);
 
-   reg 	      rreq_r;
+   reg        rreq_r;
 
    generate if (width>2)
      always @(posedge i_clk) begin
-	rdata1 <= {1'b0,rdata1[width-2:1]}; //Optimize?
-	if (rtrig1)
-	  rdata1[width-2:0] <= i_rdata[width-1:1];
+        rdata1 <= {1'b0,rdata1[width-2:1]}; //Optimize?
+        if (rtrig1)
+          rdata1[width-2:0] <= i_rdata[width-1:1];
      end
    else
      always @(posedge i_clk) if (rtrig1) rdata1 <= i_rdata[1];
@@ -126,22 +126,22 @@ module serv_rf_ram_if
       rtrig1 <= rtrig0;
       rcnt <= rcnt+5'd1;
       if (i_rreq)
-	 rcnt <= 5'd0;
+         rcnt <= 5'd0;
       if (i_wreq)
-	 rcnt <= 5'd2;
+         rcnt <= 5'd2;
 
       rreq_r <= i_rreq;
       rgnt <= rreq_r;
 
       rdata0 <= {1'b0,rdata0[width-1:1]};
       if (rtrig0)
-	rdata0 <= i_rdata;
+        rdata0 <= i_rdata;
 
       if (i_rst) begin
-	 if (reset_strategy != "NONE") begin
-	    rgnt <= 1'b0;
-	    rreq_r <= 1'b0;
-	 end
+         if (reset_strategy != "NONE") begin
+            rgnt <= 1'b0;
+            rreq_r <= 1'b0;
+         end
       end
    end
 

--- a/rtl/serv_rf_top.v
+++ b/rtl/serv_rf_top.v
@@ -12,18 +12,18 @@ module serv_rf_top
     parameter RESET_STRATEGY = "MINI",
     parameter WITH_CSR = 1,
     parameter RF_WIDTH = 2,
-	parameter RF_L2D   = $clog2((32+(WITH_CSR*4))*32/RF_WIDTH))
+        parameter RF_L2D   = $clog2((32+(WITH_CSR*4))*32/RF_WIDTH))
   (
-   input wire 	      clk,
-   input wire 	      i_rst,
-   input wire 	      i_timer_irq,
+   input wire         clk,
+   input wire         i_rst,
+   input wire         i_timer_irq,
 `ifdef RISCV_FORMAL
-   output wire 	      rvfi_valid,
+   output wire        rvfi_valid,
    output wire [63:0] rvfi_order,
    output wire [31:0] rvfi_insn,
-   output wire 	      rvfi_trap,
-   output wire 	      rvfi_halt,
-   output wire 	      rvfi_intr,
+   output wire        rvfi_trap,
+   output wire        rvfi_halt,
+   output wire        rvfi_intr,
    output wire [1:0]  rvfi_mode,
    output wire [1:0]  rvfi_ixl,
    output wire [4:0]  rvfi_rs1_addr,
@@ -41,36 +41,36 @@ module serv_rf_top
    output wire [31:0] rvfi_mem_wdata,
 `endif
    output wire [31:0] o_ibus_adr,
-   output wire 	      o_ibus_cyc,
+   output wire        o_ibus_cyc,
    input wire [31:0]  i_ibus_rdt,
-   input wire 	      i_ibus_ack,
+   input wire         i_ibus_ack,
    output wire [31:0] o_dbus_adr,
    output wire [31:0] o_dbus_dat,
    output wire [3:0]  o_dbus_sel,
-   output wire 	      o_dbus_we ,
-   output wire 	      o_dbus_cyc,
+   output wire        o_dbus_we ,
+   output wire        o_dbus_cyc,
    input wire [31:0]  i_dbus_rdt,
-   input wire 	      i_dbus_ack);
+   input wire         i_dbus_ack);
 
    localparam CSR_REGS = WITH_CSR*4;
 
-   wire 	      rf_wreq;
-   wire 	      rf_rreq;
+   wire               rf_wreq;
+   wire               rf_rreq;
    wire [4+WITH_CSR:0] wreg0;
    wire [4+WITH_CSR:0] wreg1;
-   wire 	      wen0;
-   wire 	      wen1;
-   wire 	      wdata0;
-   wire 	      wdata1;
+   wire               wen0;
+   wire               wen1;
+   wire               wdata0;
+   wire               wdata1;
    wire [4+WITH_CSR:0] rreg0;
    wire [4+WITH_CSR:0] rreg1;
-   wire 	      rf_ready;
-   wire 	      rdata0;
-   wire 	      rdata1;
+   wire               rf_ready;
+   wire               rdata0;
+   wire               rdata1;
 
    wire [RF_L2D-1:0]   waddr;
    wire [RF_WIDTH-1:0] wdata;
-   wire 	       wen;
+   wire                wen;
    wire [RF_L2D-1:0]   raddr;
    wire [RF_WIDTH-1:0] rdata;
 

--- a/rtl/serv_state.v
+++ b/rtl/serv_state.v
@@ -2,55 +2,55 @@ module serv_state
   #(parameter RESET_STRATEGY = "MINI",
     parameter [0:0] WITH_CSR = 1)
   (
-   input wire 	     i_clk,
-   input wire 	     i_rst,
-   input wire 	     i_new_irq,
-   input wire 	     i_dbus_ack,
-   output wire 	     o_ibus_cyc,
-   input wire 	     i_ibus_ack,
-   output wire 	     o_rf_rreq,
-   output wire 	     o_rf_wreq,
-   input wire 	     i_rf_ready,
-   output wire 	     o_rf_rd_en,
-   input wire 	     i_cond_branch,
-   input wire 	     i_bne_or_bge,
-   input wire 	     i_alu_cmp,
-   input wire 	     i_branch_op,
-   input wire 	     i_mem_op,
-   input wire 	     i_shift_op,
-   input wire 	     i_sh_right,
-   input wire 	     i_slt_op,
-   input wire 	     i_e_op,
-   input wire 	     i_rd_op,
-   output wire 	     o_init,
-   output wire 	     o_cnt_en,
-   output wire 	     o_cnt0,
-   output wire 	     o_cnt0to3,
-   output wire 	     o_cnt12to31,
-   output wire 	     o_cnt1,
-   output wire 	     o_cnt2,
-   output wire 	     o_cnt3,
-   output wire 	     o_cnt7,
-   output wire 	     o_ctrl_pc_en,
-   output reg 	     o_ctrl_jump,
-   output wire 	     o_ctrl_trap,
-   input wire 	     i_ctrl_misalign,
-   input wire 	     i_sh_done,
-   input wire 	     i_sh_done_r,
-   output wire 	     o_dbus_cyc,
+   input wire        i_clk,
+   input wire        i_rst,
+   input wire        i_new_irq,
+   input wire        i_dbus_ack,
+   output wire       o_ibus_cyc,
+   input wire        i_ibus_ack,
+   output wire       o_rf_rreq,
+   output wire       o_rf_wreq,
+   input wire        i_rf_ready,
+   output wire       o_rf_rd_en,
+   input wire        i_cond_branch,
+   input wire        i_bne_or_bge,
+   input wire        i_alu_cmp,
+   input wire        i_branch_op,
+   input wire        i_mem_op,
+   input wire        i_shift_op,
+   input wire        i_sh_right,
+   input wire        i_slt_op,
+   input wire        i_e_op,
+   input wire        i_rd_op,
+   output wire       o_init,
+   output wire       o_cnt_en,
+   output wire       o_cnt0,
+   output wire       o_cnt0to3,
+   output wire       o_cnt12to31,
+   output wire       o_cnt1,
+   output wire       o_cnt2,
+   output wire       o_cnt3,
+   output wire       o_cnt7,
+   output wire       o_ctrl_pc_en,
+   output reg        o_ctrl_jump,
+   output wire       o_ctrl_trap,
+   input wire        i_ctrl_misalign,
+   input wire        i_sh_done,
+   input wire        i_sh_done_r,
+   output wire       o_dbus_cyc,
    output wire [1:0] o_mem_bytecnt,
-   input wire 	     i_mem_misalign,
-   output reg 	     o_cnt_done,
-   output wire 	     o_bufreg_en);
+   input wire        i_mem_misalign,
+   output reg        o_cnt_done,
+   output wire       o_bufreg_en);
 
-   reg 	stage_two_req;
-   reg 	init_done;
+   reg  stage_two_req;
+   reg  init_done;
    wire misalign_trap_sync;
 
    reg [4:2] o_cnt;
    reg [3:0] o_cnt_r;
 
-   reg 	     ibus_cyc;
+   reg       ibus_cyc;
    //Update PC in RUN or TRAP states
    assign o_ctrl_pc_en  = o_cnt_en & !o_init;
 
@@ -86,9 +86,9 @@ module serv_state
    //Prepare RF for writes when everything is ready to enter stage two
    // and the first stage didn't cause a misalign exception
    assign o_rf_wreq = !misalign_trap_sync &
-		      ((i_shift_op & (i_sh_done | !i_sh_right) & !o_cnt_en & init_done) |
-		       (i_mem_op & i_dbus_ack) |
-		       (stage_two_req & (i_slt_op | i_branch_op)));
+                      ((i_shift_op & (i_sh_done | !i_sh_right) & !o_cnt_en & init_done) |
+                       (i_mem_op & i_dbus_ack) |
+                       (stage_two_req & (i_slt_op | i_branch_op)));
 
    assign o_rf_rd_en = i_rd_op & !o_init;
 
@@ -120,11 +120,11 @@ module serv_state
       //3. When i_ibus_ack, a new instruction is fetched and o_ibus_cyc gets
       //   deasserted to finish the transaction
       if (i_ibus_ack | o_cnt_done | i_rst)
-	ibus_cyc <= o_ctrl_pc_en | i_rst;
+        ibus_cyc <= o_ctrl_pc_en | i_rst;
 
       if (o_cnt_done) begin
-	 init_done <= o_init & !init_done;
-	 o_ctrl_jump <= o_init & take_branch;
+         init_done <= o_init & !init_done;
+         o_ctrl_jump <= o_init & take_branch;
       end
       o_cnt_done <= (o_cnt[4:2] == 3'b111) & o_cnt_r[2];
 
@@ -156,12 +156,12 @@ module serv_state
       o_cnt <= o_cnt + {2'd0,o_cnt_r[3]};
       o_cnt_r <= {o_cnt_r[2:0],(o_cnt_r[3] & !o_cnt_done) | (i_rf_ready & !o_cnt_en)};
       if (i_rst) begin
-	 if (RESET_STRATEGY != "NONE") begin
-	    o_cnt   <= 3'd0;
-	    init_done <= 1'b0;
-	    o_ctrl_jump <= 1'b0;
-	    o_cnt_r <= 4'b0000;
-	 end
+         if (RESET_STRATEGY != "NONE") begin
+            o_cnt   <= 3'd0;
+            init_done <= 1'b0;
+            o_ctrl_jump <= 1'b0;
+            o_cnt_r <= 4'b0000;
+         end
       end
    end
 
@@ -169,22 +169,22 @@ module serv_state
 
    generate
       if (WITH_CSR) begin
-	 reg 	misalign_trap_sync_r;
+         reg    misalign_trap_sync_r;
 
-	 //trap_pending is only guaranteed to have correct value during the
-	 // last cycle of the init stage
-	 wire trap_pending = WITH_CSR & ((take_branch & i_ctrl_misalign) |
-					 (i_mem_op    & i_mem_misalign));
+         //trap_pending is only guaranteed to have correct value during the
+         // last cycle of the init stage
+         wire trap_pending = WITH_CSR & ((take_branch & i_ctrl_misalign) |
+                                         (i_mem_op    & i_mem_misalign));
 
-	 always @(posedge i_clk) begin
-	    if (o_cnt_done)
-	      misalign_trap_sync_r <= trap_pending & o_init;
-	    if (i_rst)
-	      if (RESET_STRATEGY != "NONE")
-		misalign_trap_sync_r <= 1'b0;
-	 end
-	 assign misalign_trap_sync = misalign_trap_sync_r;
+         always @(posedge i_clk) begin
+            if (o_cnt_done)
+              misalign_trap_sync_r <= trap_pending & o_init;
+            if (i_rst)
+              if (RESET_STRATEGY != "NONE")
+                misalign_trap_sync_r <= 1'b0;
+         end
+         assign misalign_trap_sync = misalign_trap_sync_r;
       end else
-	assign misalign_trap_sync = 1'b0;
+        assign misalign_trap_sync = 1'b0;
    endgenerate
 endmodule

--- a/rtl/serv_top.v
+++ b/rtl/serv_top.v
@@ -5,79 +5,79 @@ module serv_top
     parameter RESET_STRATEGY = "MINI",
     parameter RESET_PC = 32'd0)
    (
-   input wire 		      clk,
-   input wire 		      i_rst,
-   input wire 		      i_timer_irq,
+   input wire                 clk,
+   input wire                 i_rst,
+   input wire                 i_timer_irq,
 `ifdef RISCV_FORMAL
-   output reg 		      rvfi_valid = 1'b0,
-   output reg [63:0] 	      rvfi_order = 64'd0,
-   output reg [31:0] 	      rvfi_insn = 32'd0,
-   output reg 		      rvfi_trap = 1'b0,
-   output reg 		      rvfi_halt = 1'b0,
-   output reg 		      rvfi_intr = 1'b0,
-   output reg [1:0] 	      rvfi_mode = 2'b11,
-   output reg [1:0] 	      rvfi_ixl = 2'b01,
-   output reg [4:0] 	      rvfi_rs1_addr,
-   output reg [4:0] 	      rvfi_rs2_addr,
-   output reg [31:0] 	      rvfi_rs1_rdata,
-   output reg [31:0] 	      rvfi_rs2_rdata,
-   output reg [4:0] 	      rvfi_rd_addr,
-   output reg [31:0] 	      rvfi_rd_wdata,
-   output reg [31:0] 	      rvfi_pc_rdata,
-   output reg [31:0] 	      rvfi_pc_wdata,
-   output reg [31:0] 	      rvfi_mem_addr,
-   output reg [3:0] 	      rvfi_mem_rmask,
-   output reg [3:0] 	      rvfi_mem_wmask,
-   output reg [31:0] 	      rvfi_mem_rdata,
-   output reg [31:0] 	      rvfi_mem_wdata,
+   output reg                 rvfi_valid = 1'b0,
+   output reg [63:0]          rvfi_order = 64'd0,
+   output reg [31:0]          rvfi_insn = 32'd0,
+   output reg                 rvfi_trap = 1'b0,
+   output reg                 rvfi_halt = 1'b0,
+   output reg                 rvfi_intr = 1'b0,
+   output reg [1:0]           rvfi_mode = 2'b11,
+   output reg [1:0]           rvfi_ixl = 2'b01,
+   output reg [4:0]           rvfi_rs1_addr,
+   output reg [4:0]           rvfi_rs2_addr,
+   output reg [31:0]          rvfi_rs1_rdata,
+   output reg [31:0]          rvfi_rs2_rdata,
+   output reg [4:0]           rvfi_rd_addr,
+   output reg [31:0]          rvfi_rd_wdata,
+   output reg [31:0]          rvfi_pc_rdata,
+   output reg [31:0]          rvfi_pc_wdata,
+   output reg [31:0]          rvfi_mem_addr,
+   output reg [3:0]           rvfi_mem_rmask,
+   output reg [3:0]           rvfi_mem_wmask,
+   output reg [31:0]          rvfi_mem_rdata,
+   output reg [31:0]          rvfi_mem_wdata,
 `endif
    //RF Interface
-   output wire 		      o_rf_rreq,
-   output wire 		      o_rf_wreq,
-   input wire 		      i_rf_ready,
+   output wire                o_rf_rreq,
+   output wire                o_rf_wreq,
+   input wire                 i_rf_ready,
    output wire [4+WITH_CSR:0] o_wreg0,
    output wire [4+WITH_CSR:0] o_wreg1,
-   output wire 		      o_wen0,
-   output wire 		      o_wen1,
-   output wire 		      o_wdata0,
-   output wire 		      o_wdata1,
+   output wire                o_wen0,
+   output wire                o_wen1,
+   output wire                o_wdata0,
+   output wire                o_wdata1,
    output wire [4+WITH_CSR:0] o_rreg0,
    output wire [4+WITH_CSR:0] o_rreg1,
-   input wire 		      i_rdata0,
-   input wire 		      i_rdata1,
+   input wire                 i_rdata0,
+   input wire                 i_rdata1,
 
-   output wire [31:0] 	      o_ibus_adr,
-   output wire 		      o_ibus_cyc,
-   input wire [31:0] 	      i_ibus_rdt,
-   input wire 		      i_ibus_ack,
-   output wire [31:0] 	      o_dbus_adr,
-   output wire [31:0] 	      o_dbus_dat,
-   output wire [3:0] 	      o_dbus_sel,
-   output wire 		      o_dbus_we ,
-   output wire 		      o_dbus_cyc,
-   input wire [31:0] 	      i_dbus_rdt,
-   input wire 		      i_dbus_ack);
+   output wire [31:0]         o_ibus_adr,
+   output wire                o_ibus_cyc,
+   input wire [31:0]          i_ibus_rdt,
+   input wire                 i_ibus_ack,
+   output wire [31:0]         o_dbus_adr,
+   output wire [31:0]         o_dbus_dat,
+   output wire [3:0]          o_dbus_sel,
+   output wire                o_dbus_we ,
+   output wire                o_dbus_cyc,
+   input wire [31:0]          i_dbus_rdt,
+   input wire                 i_dbus_ack);
 
    wire [4:0]    rd_addr;
    wire [4:0]    rs1_addr;
    wire [4:0]    rs2_addr;
 
-   wire [3:0] 	 immdec_ctrl;
-   wire [3:0] 	immdec_en;
+   wire [3:0]    immdec_ctrl;
+   wire [3:0]   immdec_en;
 
    wire          sh_right;
-   wire 	 bne_or_bge;
-   wire 	 cond_branch;
-   wire 	 e_op;
-   wire 	 ebreak;
-   wire 	 branch_op;
+   wire          bne_or_bge;
+   wire          cond_branch;
+   wire          e_op;
+   wire          ebreak;
+   wire          branch_op;
    wire          mem_op;
-   wire 	 shift_op;
-   wire 	 slt_op;
-   wire 	 rd_op;
+   wire          shift_op;
+   wire          slt_op;
+   wire          rd_op;
 
-   wire 	 rd_alu_en;
-   wire 	 rd_csr_en;
+   wire          rd_alu_en;
+   wire          rd_csr_en;
    wire          ctrl_rd;
    wire          alu_rd;
    wire          mem_rd;
@@ -87,32 +87,32 @@ module serv_top
    wire          jump;
    wire          jal_or_jalr;
    wire          utype;
-   wire 	 mret;
+   wire          mret;
    wire          imm;
-   wire 	 trap;
-   wire 	 pc_rel;
+   wire          trap;
+   wire          pc_rel;
 
    wire          init;
    wire          cnt_en;
-   wire 	 cnt0to3;
-   wire 	 cnt12to31;
+   wire          cnt0to3;
+   wire          cnt12to31;
    wire          cnt0;
    wire          cnt1;
    wire          cnt2;
    wire          cnt3;
    wire          cnt7;
 
-   wire 	 cnt_done;
+   wire          cnt_done;
 
-   wire 	 bufreg_en;
+   wire          bufreg_en;
    wire          bufreg_sh_signed;
-   wire 	 bufreg_rs1_en;
-   wire 	 bufreg_imm_en;
-   wire 	 bufreg_clr_lsb;
-   wire 	 bufreg_q;
+   wire          bufreg_rs1_en;
+   wire          bufreg_imm_en;
+   wire          bufreg_clr_lsb;
+   wire          bufreg_q;
 
    wire          alu_sub;
-   wire [1:0] 	 alu_bool_op;
+   wire [1:0]    alu_bool_op;
    wire          alu_cmp_eq;
    wire          alu_cmp_sig;
    wire          alu_cmp;
@@ -127,32 +127,32 @@ module serv_top
    wire          mem_signed;
    wire          mem_word;
    wire          mem_half;
-   wire [1:0] 	 mem_bytecnt;
-   wire 	 mem_sh_done;
-   wire 	 mem_sh_done_r;
+   wire [1:0]    mem_bytecnt;
+   wire          mem_sh_done;
+   wire          mem_sh_done_r;
 
-   wire 	 mem_misalign;
+   wire          mem_misalign;
 
-   wire 	 bad_pc;
+   wire          bad_pc;
 
-   wire 	 csr_mstatus_en;
-   wire 	 csr_mie_en;
-   wire 	 csr_mcause_en;
-   wire [1:0]	 csr_source;
-   wire 	 csr_imm;
-   wire 	 csr_d_sel;
-   wire 	 csr_en;
-   wire [1:0] 	 csr_addr;
-   wire 	 csr_pc;
-   wire 	 csr_imm_en;
-   wire 	 csr_in;
-   wire 	 rf_csr_out;
+   wire          csr_mstatus_en;
+   wire          csr_mie_en;
+   wire          csr_mcause_en;
+   wire [1:0]    csr_source;
+   wire          csr_imm;
+   wire          csr_d_sel;
+   wire          csr_en;
+   wire [1:0]    csr_addr;
+   wire          csr_pc;
+   wire          csr_imm_en;
+   wire          csr_in;
+   wire          rf_csr_out;
 
-   wire 	 new_irq;
+   wire          new_irq;
 
    wire [1:0]   lsb;
 
-   wire 	op_b = op_b_source ? rs2 : imm;
+   wire         op_b = op_b_source ? rs2 : imm;
 
    serv_state
      #(.RESET_STRATEGY (RESET_STRATEGY),
@@ -425,46 +425,46 @@ module serv_top
 
    generate
       if (WITH_CSR) begin
-	 serv_csr csr
-	   (
-	    .i_clk        (clk),
-	    //State
-	    .i_init       (init),
-	    .i_en         (cnt_en),
-	    .i_cnt0to3    (cnt0to3),
-	    .i_cnt3       (cnt3),
-	    .i_cnt7       (cnt7),
-	    .i_cnt_done   (cnt_done),
-	    .i_mem_op     (mem_op),
-	    .i_mtip       (i_timer_irq),
-	    .i_trap       (trap),
-	    .o_new_irq    (new_irq),
-	    //Control
-	    .i_e_op       (e_op),
-	    .i_ebreak     (ebreak),
-	    .i_mem_cmd    (o_dbus_we),
-	    .i_mstatus_en (csr_mstatus_en),
-	    .i_mie_en     (csr_mie_en    ),
-	    .i_mcause_en  (csr_mcause_en ),
-	    .i_csr_source (csr_source),
-	    .i_mret       (mret),
-	    .i_csr_d_sel  (csr_d_sel),
-	    //Data
-	    .i_rf_csr_out (rf_csr_out),
-	    .o_csr_in     (csr_in),
-	    .i_csr_imm    (csr_imm),
-	    .i_rs1        (rs1),
-	    .o_q          (csr_rd));
+         serv_csr csr
+           (
+            .i_clk        (clk),
+            //State
+            .i_init       (init),
+            .i_en         (cnt_en),
+            .i_cnt0to3    (cnt0to3),
+            .i_cnt3       (cnt3),
+            .i_cnt7       (cnt7),
+            .i_cnt_done   (cnt_done),
+            .i_mem_op     (mem_op),
+            .i_mtip       (i_timer_irq),
+            .i_trap       (trap),
+            .o_new_irq    (new_irq),
+            //Control
+            .i_e_op       (e_op),
+            .i_ebreak     (ebreak),
+            .i_mem_cmd    (o_dbus_we),
+            .i_mstatus_en (csr_mstatus_en),
+            .i_mie_en     (csr_mie_en    ),
+            .i_mcause_en  (csr_mcause_en ),
+            .i_csr_source (csr_source),
+            .i_mret       (mret),
+            .i_csr_d_sel  (csr_d_sel),
+            //Data
+            .i_rf_csr_out (rf_csr_out),
+            .o_csr_in     (csr_in),
+            .i_csr_imm    (csr_imm),
+            .i_rs1        (rs1),
+            .o_q          (csr_rd));
       end else begin
-	 assign csr_in = 1'b0;
-	 assign csr_rd = 1'b0;
-	 assign new_irq = 1'b0;
+         assign csr_in = 1'b0;
+         assign csr_rd = 1'b0;
+         assign new_irq = 1'b0;
       end
    endgenerate
 
 
 `ifdef RISCV_FORMAL
-   reg [31:0] 	 pc = RESET_PC;
+   reg [31:0]    pc = RESET_PC;
 
    wire rs_en = (branch_op|mem_op|shift_op|slt_op) ? init : ctrl_pc_en;
 
@@ -472,15 +472,15 @@ module serv_top
       rvfi_valid <= cnt_done & ctrl_pc_en & !i_rst;
       rvfi_order <= rvfi_order + {63'd0,rvfi_valid};
       if (o_ibus_cyc & i_ibus_ack)
-	rvfi_insn <= i_ibus_rdt;
+        rvfi_insn <= i_ibus_rdt;
       if (o_wen0)
         rvfi_rd_wdata <= {o_wdata0,rvfi_rd_wdata[31:1]};
       if (cnt_done & ctrl_pc_en) begin
          rvfi_pc_rdata <= pc;
-	 if (!(rd_en & (|rd_addr))) begin
-	   rvfi_rd_addr <= 5'd0;
-	   rvfi_rd_wdata <= 32'd0;
-	 end
+         if (!(rd_en & (|rd_addr))) begin
+           rvfi_rd_addr <= 5'd0;
+           rvfi_rd_wdata <= 32'd0;
+         end
       end
       rvfi_trap <= trap;
       if (rvfi_valid) begin
@@ -493,9 +493,9 @@ module serv_top
       rvfi_mode <= 2'd3;
       rvfi_ixl = 2'd1;
       if (i_rf_ready) begin
-	 rvfi_rs1_addr <= rs1_addr;
+         rvfi_rs1_addr <= rs1_addr;
          rvfi_rs2_addr <= rs2_addr;
-	 rvfi_rd_addr  <= rd_addr;
+         rvfi_rd_addr  <= rd_addr;
       end
       if (rs_en) begin
          rvfi_rs1_rdata <= {rs1,rvfi_rs1_rdata[31:1]};

--- a/servant.core
+++ b/servant.core
@@ -170,7 +170,7 @@ targets:
         family : MAX 10
         device : 10M50DAF484C6GES
     toplevel: servive
-   
+
   de0_nano:
     default_tool : quartus
     filesets : [mem_files, soc, de0_nano]

--- a/servant/ecppll.v
+++ b/servant/ecppll.v
@@ -1,4 +1,4 @@
-module pll(input clki, 
+module pll(input clki,
     output locked,
     output clko
 );
@@ -33,6 +33,6 @@ EHXPLLL #(
         .PLLWAKESYNC(1'b0),
         .ENCLKOP(1'b0),
         .LOCK(locked)
-	);
+        );
 assign clko = clkop;
 endmodule

--- a/servant/ice40_pll.v
+++ b/servant/ice40_pll.v
@@ -16,25 +16,25 @@ module ice40_pll
 
    generate
       if (PLL == "ICE40_CORE") begin
-	 SB_PLL40_CORE
-	   #(`include "pll.vh")
-	 pll
-	   (
-	    .LOCK(locked),
-	    .RESETB(1'b1),
-	    .BYPASS(1'b0),
-	    .REFERENCECLK(i_clk),
-	    .PLLOUTCORE(o_clk));
+         SB_PLL40_CORE
+           #(`include "pll.vh")
+         pll
+           (
+            .LOCK(locked),
+            .RESETB(1'b1),
+            .BYPASS(1'b0),
+            .REFERENCECLK(i_clk),
+            .PLLOUTCORE(o_clk));
       end else if (PLL == "ICE40_PAD") begin
-	 SB_PLL40_PAD
-	   #(`include "pll.vh")
-	 pll
-	   (
-	    .LOCK(locked),
-	    .RESETB(1'b1),
-	    .BYPASS(1'b0),
-	    .PACKAGEPIN (i_clk),
-	    .PLLOUTCORE(o_clk));
+         SB_PLL40_PAD
+           #(`include "pll.vh")
+         pll
+           (
+            .LOCK(locked),
+            .RESETB(1'b1),
+            .BYPASS(1'b0),
+            .PACKAGEPIN (i_clk),
+            .PLLOUTCORE(o_clk));
       end
    endgenerate
 endmodule

--- a/servant/servant.v
+++ b/servant/servant.v
@@ -11,46 +11,46 @@ module servant
    parameter sim = 0;
    parameter with_csr = 1;
 
-   wire 	timer_irq;
+   wire         timer_irq;
 
-   wire [31:0] 	wb_ibus_adr;
-   wire 	wb_ibus_cyc;
-   wire [31:0] 	wb_ibus_rdt;
-   wire 	wb_ibus_ack;
+   wire [31:0]  wb_ibus_adr;
+   wire         wb_ibus_cyc;
+   wire [31:0]  wb_ibus_rdt;
+   wire         wb_ibus_ack;
 
-   wire [31:0] 	wb_dbus_adr;
-   wire [31:0] 	wb_dbus_dat;
-   wire [3:0] 	wb_dbus_sel;
-   wire 	wb_dbus_we;
-   wire 	wb_dbus_cyc;
-   wire [31:0] 	wb_dbus_rdt;
-   wire 	wb_dbus_ack;
+   wire [31:0]  wb_dbus_adr;
+   wire [31:0]  wb_dbus_dat;
+   wire [3:0]   wb_dbus_sel;
+   wire         wb_dbus_we;
+   wire         wb_dbus_cyc;
+   wire [31:0]  wb_dbus_rdt;
+   wire         wb_dbus_ack;
 
-   wire [31:0] 	wb_dmem_adr;
-   wire [31:0] 	wb_dmem_dat;
-   wire [3:0] 	wb_dmem_sel;
-   wire 	wb_dmem_we;
-   wire 	wb_dmem_cyc;
-   wire [31:0] 	wb_dmem_rdt;
-   wire 	wb_dmem_ack;
+   wire [31:0]  wb_dmem_adr;
+   wire [31:0]  wb_dmem_dat;
+   wire [3:0]   wb_dmem_sel;
+   wire         wb_dmem_we;
+   wire         wb_dmem_cyc;
+   wire [31:0]  wb_dmem_rdt;
+   wire         wb_dmem_ack;
 
-   wire [31:0] 	wb_mem_adr;
-   wire [31:0] 	wb_mem_dat;
-   wire [3:0] 	wb_mem_sel;
-   wire 	wb_mem_we;
-   wire 	wb_mem_cyc;
-   wire [31:0] 	wb_mem_rdt;
-   wire 	wb_mem_ack;
+   wire [31:0]  wb_mem_adr;
+   wire [31:0]  wb_mem_dat;
+   wire [3:0]   wb_mem_sel;
+   wire         wb_mem_we;
+   wire         wb_mem_cyc;
+   wire [31:0]  wb_mem_rdt;
+   wire         wb_mem_ack;
 
-   wire 	wb_gpio_dat;
-   wire 	wb_gpio_we;
-   wire 	wb_gpio_cyc;
-   wire 	wb_gpio_rdt;
+   wire         wb_gpio_dat;
+   wire         wb_gpio_we;
+   wire         wb_gpio_cyc;
+   wire         wb_gpio_rdt;
 
-   wire [31:0] 	wb_timer_dat;
-   wire 	wb_timer_we;
-   wire 	wb_timer_cyc;
-   wire [31:0] 	wb_timer_rdt;
+   wire [31:0]  wb_timer_dat;
+   wire         wb_timer_we;
+   wire         wb_timer_cyc;
+   wire [31:0]  wb_timer_rdt;
 
    servant_arbiter arbiter
      (.i_wb_cpu_dbus_adr (wb_dmem_adr),
@@ -121,20 +121,20 @@ module servant
 
    generate
       if (with_csr) begin
-	 servant_timer
-	   #(.RESET_STRATEGY (reset_strategy),
-	     .WIDTH (32))
-	 timer
-	   (.i_clk    (wb_clk),
-	    .i_rst    (wb_rst),
-	    .o_irq    (timer_irq),
-	    .i_wb_cyc (wb_timer_cyc),
-	    .i_wb_we  (wb_timer_we) ,
-	    .i_wb_dat (wb_timer_dat),
-	    .o_wb_dat (wb_timer_rdt));
+         servant_timer
+           #(.RESET_STRATEGY (reset_strategy),
+             .WIDTH (32))
+         timer
+           (.i_clk    (wb_clk),
+            .i_rst    (wb_rst),
+            .o_irq    (timer_irq),
+            .i_wb_cyc (wb_timer_cyc),
+            .i_wb_we  (wb_timer_we) ,
+            .i_wb_dat (wb_timer_dat),
+            .o_wb_dat (wb_timer_rdt));
       end else begin
-	 assign wb_timer_rdt = 32'd0;
-	 assign timer_irq = 1'b0;
+         assign wb_timer_rdt = 32'd0;
+         assign timer_irq = 1'b0;
       end
    endgenerate
 

--- a/servant/servant_arbiter.v
+++ b/servant/servant_arbiter.v
@@ -6,23 +6,23 @@ module servant_arbiter
    input wire [31:0]  i_wb_cpu_dbus_adr,
    input wire [31:0]  i_wb_cpu_dbus_dat,
    input wire [3:0]   i_wb_cpu_dbus_sel,
-   input wire 	      i_wb_cpu_dbus_we,
-   input wire 	      i_wb_cpu_dbus_cyc,
+   input wire         i_wb_cpu_dbus_we,
+   input wire         i_wb_cpu_dbus_cyc,
    output wire [31:0] o_wb_cpu_dbus_rdt,
-   output wire 	      o_wb_cpu_dbus_ack,
+   output wire        o_wb_cpu_dbus_ack,
 
    input wire [31:0]  i_wb_cpu_ibus_adr,
-   input wire 	      i_wb_cpu_ibus_cyc,
+   input wire         i_wb_cpu_ibus_cyc,
    output wire [31:0] o_wb_cpu_ibus_rdt,
-   output wire 	      o_wb_cpu_ibus_ack,
+   output wire        o_wb_cpu_ibus_ack,
 
    output wire [31:0] o_wb_cpu_adr,
    output wire [31:0] o_wb_cpu_dat,
    output wire [3:0]  o_wb_cpu_sel,
-   output wire 	      o_wb_cpu_we,
-   output wire 	      o_wb_cpu_cyc,
+   output wire        o_wb_cpu_we,
+   output wire        o_wb_cpu_cyc,
    input wire [31:0]  i_wb_cpu_rdt,
-   input wire 	      i_wb_cpu_ack);
+   input wire         i_wb_cpu_ack);
 
    assign o_wb_cpu_dbus_rdt = i_wb_cpu_rdt;
    assign o_wb_cpu_dbus_ack = i_wb_cpu_ack & !i_wb_cpu_ibus_cyc;

--- a/servant/servant_clock_gen.v
+++ b/servant/servant_clock_gen.v
@@ -9,18 +9,18 @@ module servant_clock_gen
 
    generate
       if ((PLL == "ICE40_CORE") || (PLL == "ICE40_PAD")) begin
-	 ice40_pll #(.PLL (PLL)) pll
-	   (.i_clk (i_clk),
-	    .o_clk (o_clk),
-	    .o_rst (o_rst));
+         ice40_pll #(.PLL (PLL)) pll
+           (.i_clk (i_clk),
+            .o_clk (o_clk),
+            .o_rst (o_rst));
       end else begin
-	 assign o_clk = i_clk;
+         assign o_clk = i_clk;
 
-	 reg [4:0] rst_reg = 5'b11111;
+         reg [4:0] rst_reg = 5'b11111;
 
-	 always @(posedge o_clk)
-	   rst_reg <= {1'b0, rst_reg[4:1]};
-	 assign o_rst = rst_reg[0];
+         always @(posedge o_clk)
+           rst_reg <= {1'b0, rst_reg[4:1]};
+         assign o_rst = rst_reg[0];
       end
    endgenerate
 endmodule

--- a/servant/servant_gpio.v
+++ b/servant/servant_gpio.v
@@ -9,6 +9,6 @@ module servant_gpio
    always @(posedge i_wb_clk) begin
       o_wb_rdt <= o_gpio;
       if (i_wb_cyc & i_wb_we)
-	o_gpio <= i_wb_dat;
+        o_gpio <= i_wb_dat;
    end
 endmodule

--- a/servant/servant_lx9_clock_gen.v
+++ b/servant/servant_lx9_clock_gen.v
@@ -7,7 +7,7 @@ module servant_lx9_clock_gen
 
    wire   clkfb;
    wire   locked;
-   reg 	  locked_r;
+   reg    locked_r;
 
    PLL_BASE
      #(.BANDWIDTH("OPTIMIZED"),

--- a/servant/servant_mux.v
+++ b/servant/servant_mux.v
@@ -6,45 +6,45 @@
  */
 module servant_mux
   (
-   input wire 	      i_clk,
-   input wire 	      i_rst,
+   input wire         i_clk,
+   input wire         i_rst,
    input wire [31:0]  i_wb_cpu_adr,
    input wire [31:0]  i_wb_cpu_dat,
    input wire [3:0]   i_wb_cpu_sel,
-   input wire 	      i_wb_cpu_we,
-   input wire 	      i_wb_cpu_cyc,
+   input wire         i_wb_cpu_we,
+   input wire         i_wb_cpu_cyc,
    output wire [31:0] o_wb_cpu_rdt,
-   output reg 	      o_wb_cpu_ack,
+   output reg         o_wb_cpu_ack,
 
    output wire [31:0] o_wb_mem_adr,
    output wire [31:0] o_wb_mem_dat,
    output wire [3:0]  o_wb_mem_sel,
-   output wire 	      o_wb_mem_we,
-   output wire 	      o_wb_mem_cyc,
+   output wire        o_wb_mem_we,
+   output wire        o_wb_mem_cyc,
    input wire [31:0]  i_wb_mem_rdt,
 
-   output wire 	      o_wb_gpio_dat,
-   output wire 	      o_wb_gpio_we,
-   output wire 	      o_wb_gpio_cyc,
-   input wire 	      i_wb_gpio_rdt,
+   output wire        o_wb_gpio_dat,
+   output wire        o_wb_gpio_we,
+   output wire        o_wb_gpio_cyc,
+   input wire         i_wb_gpio_rdt,
 
    output wire [31:0] o_wb_timer_dat,
-   output wire 	      o_wb_timer_we,
-   output wire 	      o_wb_timer_cyc,
+   output wire        o_wb_timer_we,
+   output wire        o_wb_timer_cyc,
    input wire [31:0]  i_wb_timer_rdt);
 
    parameter sim = 0;
 
-   wire [1:0] 	  s = i_wb_cpu_adr[31:30];
+   wire [1:0]     s = i_wb_cpu_adr[31:30];
 
    assign o_wb_cpu_rdt = s[1] ? i_wb_timer_rdt :
-			 s[0] ? {31'd0,i_wb_gpio_rdt} : i_wb_mem_rdt;
+                         s[0] ? {31'd0,i_wb_gpio_rdt} : i_wb_mem_rdt;
    always @(posedge i_clk) begin
       o_wb_cpu_ack <= 1'b0;
       if (i_wb_cpu_cyc & !o_wb_cpu_ack)
-	o_wb_cpu_ack <= 1'b1;
+        o_wb_cpu_ack <= 1'b1;
       if (i_rst)
-	o_wb_cpu_ack <= 1'b0;
+        o_wb_cpu_ack <= 1'b0;
    end
 
    assign o_wb_mem_adr = i_wb_cpu_adr;
@@ -63,27 +63,27 @@ module servant_mux
 
    generate
       if (sim) begin
-	 wire sig_en = (i_wb_cpu_adr[31:28] == 4'h8) & i_wb_cpu_cyc & o_wb_cpu_ack;
-	 wire halt_en = (i_wb_cpu_adr[31:28] == 4'h9) & i_wb_cpu_cyc & o_wb_cpu_ack;
+         wire sig_en = (i_wb_cpu_adr[31:28] == 4'h8) & i_wb_cpu_cyc & o_wb_cpu_ack;
+         wire halt_en = (i_wb_cpu_adr[31:28] == 4'h9) & i_wb_cpu_cyc & o_wb_cpu_ack;
 
-	 reg [1023:0] signature_file;
-	 integer      f = 0;
+         reg [1023:0] signature_file;
+         integer      f = 0;
 
-	 initial
+         initial
        /* verilator lint_off WIDTH */
-	   if ($value$plusargs("signature=%s", signature_file)) begin
-	      $display("Writing signature to %0s", signature_file);
-	      f = $fopen(signature_file, "w");
-	   end
+           if ($value$plusargs("signature=%s", signature_file)) begin
+              $display("Writing signature to %0s", signature_file);
+              f = $fopen(signature_file, "w");
+           end
        /* verilator lint_on WIDTH */
 
-	 always @(posedge i_clk)
-	    if (sig_en & (f != 0))
-	      $fwrite(f, "%c", i_wb_cpu_dat[7:0]);
-	    else if(halt_en) begin
-	       $display("Test complete");
-	       $finish;
-	    end
+         always @(posedge i_clk)
+            if (sig_en & (f != 0))
+              $fwrite(f, "%c", i_wb_cpu_dat[7:0]);
+            else if(halt_en) begin
+               $display("Test complete");
+               $finish;
+            end
       end
    endgenerate
 endmodule

--- a/servant/servant_orangecrab.v
+++ b/servant/servant_orangecrab.v
@@ -79,7 +79,7 @@ module servant_orangecrab
    reg wb_rst;
    always @(posedge wb_clk)
        wb_rst <= ~pll_locked;
-   
+
    wire q;
    servant
      #(.memfile (memfile),

--- a/servant/servant_ram.v
+++ b/servant/servant_ram.v
@@ -5,21 +5,21 @@ module servant_ram
     parameter aw    = $clog2(depth),
     parameter RESET_STRATEGY = "",
     parameter memfile = "")
-   (input wire 		i_wb_clk,
-    input wire 		i_wb_rst,
+   (input wire          i_wb_clk,
+    input wire          i_wb_rst,
     input wire [aw-1:2] i_wb_adr,
-    input wire [31:0] 	i_wb_dat,
-    input wire [3:0] 	i_wb_sel,
-    input wire 		i_wb_we,
-    input wire 		i_wb_cyc,
-    output reg [31:0] 	o_wb_rdt,
-    output reg 		o_wb_ack);
+    input wire [31:0]   i_wb_dat,
+    input wire [3:0]    i_wb_sel,
+    input wire          i_wb_we,
+    input wire          i_wb_cyc,
+    output reg [31:0]   o_wb_rdt,
+    output reg          o_wb_ack);
 
-   wire [3:0] 		we = {4{i_wb_we & i_wb_cyc}} & i_wb_sel;
+   wire [3:0]           we = {4{i_wb_we & i_wb_cyc}} & i_wb_sel;
 
-   reg [31:0] 		mem [0:depth/4-1] /* verilator public */;
+   reg [31:0]           mem [0:depth/4-1] /* verilator public */;
 
-   wire [aw-3:0] 	addr = i_wb_adr[aw-1:2];
+   wire [aw-3:0]        addr = i_wb_adr[aw-1:2];
 
    always @(posedge i_wb_clk)
      if (i_wb_rst & (RESET_STRATEGY != "NONE"))
@@ -38,9 +38,9 @@ module servant_ram
    initial
      if(|memfile) begin
 `ifndef ISE
-	$display("Preloading %m from %s", memfile);
+        $display("Preloading %m from %s", memfile);
 `endif
-	$readmemh(memfile, mem);
+        $readmemh(memfile, mem);
      end
 
 endmodule

--- a/servant/servant_timer.v
+++ b/servant/servant_timer.v
@@ -3,12 +3,12 @@ module servant_timer
   #(parameter WIDTH = 16,
     parameter RESET_STRATEGY = "",
     parameter DIVIDER = 0)
-  (input wire 	     i_clk,
-   input wire 	     i_rst,
-   output reg 	     o_irq,
+  (input wire        i_clk,
+   input wire        i_rst,
+   output reg        o_irq,
    input wire [31:0] i_wb_dat,
-   input wire 	     i_wb_we,
-   input wire 	     i_wb_cyc,
+   input wire        i_wb_we,
+   input wire        i_wb_cyc,
    output reg [31:0] o_wb_dat);
 
    localparam HIGH = WIDTH-1-DIVIDER;
@@ -25,13 +25,13 @@ module servant_timer
 
    always @(posedge i_clk) begin
       if (i_wb_cyc & i_wb_we)
-	mtimecmp <= i_wb_dat[HIGH:0];
+        mtimecmp <= i_wb_dat[HIGH:0];
       mtime <= mtime + 'd1;
       o_irq <= (mtimeslice >= mtimecmp);
       if (RESET_STRATEGY != "NONE")
-	if (i_rst) begin
-	   mtime <= 0;
-	   mtimecmp <= 0;
-	end
+        if (i_rst) begin
+           mtime <= 0;
+           mtimecmp <= 0;
+        end
    end
 endmodule

--- a/servant/servant_upduino2.v
+++ b/servant/servant_upduino2.v
@@ -51,14 +51,14 @@ module servant_upduino2
       .RGB1(b),
       .RGB2(r));
 
-   reg 	     rst = 1'b1;
+   reg       rst = 1'b1;
 
 /*
    //Delayed reset
    reg [25:0] cnt;
    always @(posedge clk) begin
       if (!cnt[25])
-	cnt <= cnt + 1;
+        cnt <= cnt + 1;
       rst <= !cnt[25];
    end
  */

--- a/servant/servclone10.v
+++ b/servant/servclone10.v
@@ -1,10 +1,10 @@
 `default_nettype none
 module servclone10
 (
- input wire 	   i_clk,
- input wire 	   i_rst,
- output wire 	   q,
- output wire 	   uart_txd);
+ input wire        i_clk,
+ input wire        i_rst,
+ output wire       q,
+ output wire       uart_txd);
 
    parameter memfile = "zephyr_hello.hex";
    parameter memsize = 8192;

--- a/servant/servis_clock_gen.v
+++ b/servant/servis_clock_gen.v
@@ -6,7 +6,7 @@ module servis_clock_gen
 
    wire   clkfb;
    wire   locked;
-   reg 	  locked_r;
+   reg    locked_r;
 
    PLL_BASE
      #(.BANDWIDTH("OPTIMIZED"),

--- a/servant/servive.v
+++ b/servant/servive.v
@@ -1,10 +1,10 @@
 `default_nettype none
 module servive
 (
- input wire 	   i_clk,
- input wire 	   i_rst_n,
- output wire 	   q,
- output wire 	   uart_txd);
+ input wire        i_clk,
+ input wire        i_rst_n,
+ output wire       q,
+ output wire       uart_txd);
 
    parameter memfile = "zephyr_hello.hex";
    parameter memsize = 8192;

--- a/servant/servive_clock_gen.v
+++ b/servant/servive_clock_gen.v
@@ -16,9 +16,9 @@ module servive_clock_gen
      else
        r <= 10'b1111111111;
 
-   wire [5:0] 	  clk;
+   wire [5:0]     clk;
 
-   assign 	  o_clk = clk[0];
+   assign         o_clk = clk[0];
 
    altpll
      #(.operation_mode         ("NORMAL"),

--- a/servant/servix_clock_gen.v
+++ b/servant/servix_clock_gen.v
@@ -8,7 +8,7 @@ module servix_clock_gen
 
    wire   clkfb;
    wire   locked;
-   reg 	  locked_r;
+   reg    locked_r;
 
    PLLE2_BASE
      #(.BANDWIDTH("OPTIMIZED"),

--- a/servant/servus_clock_gen.v
+++ b/servant/servus_clock_gen.v
@@ -6,7 +6,7 @@ module servus_clock_gen
 
    wire   clkfb;
    wire   locked;
-   reg 	  locked_r;
+   reg    locked_r;
 
    MMCME4_ADV
      #(.DIVCLK_DIVIDE    (5),

--- a/serving/serving.v
+++ b/serving/serving.v
@@ -20,17 +20,17 @@
 `default_nettype none
 module serving
   (
-   input wire 	      i_clk,
-   input wire 	      i_rst,
-   input wire 	      i_timer_irq,
+   input wire         i_clk,
+   input wire         i_rst,
+   input wire         i_timer_irq,
 
    output wire [31:0] o_wb_adr,
    output wire [31:0] o_wb_dat,
    output wire [3:0]  o_wb_sel,
-   output wire 	      o_wb_we ,
-   output wire 	      o_wb_stb,
+   output wire        o_wb_we ,
+   output wire        o_wb_stb,
    input wire [31:0]  i_wb_rdt,
-   input wire 	      i_wb_ack);
+   input wire         i_wb_ack);
 
    parameter memfile = "";
    parameter memsize = 8192;
@@ -42,38 +42,38 @@ module serving
 
    localparam aw = $clog2(memsize);
 
-   wire [31:0] 	wb_ibus_adr;
-   wire 	wb_ibus_stb;
-   wire [31:0] 	wb_ibus_rdt;
-   wire 	wb_ibus_ack;
+   wire [31:0]  wb_ibus_adr;
+   wire         wb_ibus_stb;
+   wire [31:0]  wb_ibus_rdt;
+   wire         wb_ibus_ack;
 
-   wire [31:0] 	wb_dbus_adr;
-   wire [31:0] 	wb_dbus_dat;
-   wire [3:0] 	wb_dbus_sel;
-   wire 	wb_dbus_we;
-   wire 	wb_dbus_stb;
-   wire [31:0] 	wb_dbus_rdt;
-   wire 	wb_dbus_ack;
+   wire [31:0]  wb_dbus_adr;
+   wire [31:0]  wb_dbus_dat;
+   wire [3:0]   wb_dbus_sel;
+   wire         wb_dbus_we;
+   wire         wb_dbus_stb;
+   wire [31:0]  wb_dbus_rdt;
+   wire         wb_dbus_ack;
 
-   wire [31:0] 	wb_dmem_adr;
-   wire [31:0] 	wb_dmem_dat;
-   wire [3:0] 	wb_dmem_sel;
-   wire 	wb_dmem_we;
-   wire 	wb_dmem_stb;
-   wire [31:0] 	wb_dmem_rdt;
-   wire 	wb_dmem_ack;
+   wire [31:0]  wb_dmem_adr;
+   wire [31:0]  wb_dmem_dat;
+   wire [3:0]   wb_dmem_sel;
+   wire         wb_dmem_we;
+   wire         wb_dmem_stb;
+   wire [31:0]  wb_dmem_rdt;
+   wire         wb_dmem_ack;
 
-   wire [31:0] 	wb_mem_adr;
-   wire [31:0] 	wb_mem_dat;
-   wire [3:0] 	wb_mem_sel;
-   wire 	wb_mem_we;
-   wire 	wb_mem_stb;
-   wire [31:0] 	wb_mem_rdt;
-   wire 	wb_mem_ack;
+   wire [31:0]  wb_mem_adr;
+   wire [31:0]  wb_mem_dat;
+   wire [3:0]   wb_mem_sel;
+   wire         wb_mem_we;
+   wire         wb_mem_stb;
+   wire [31:0]  wb_mem_rdt;
+   wire         wb_mem_ack;
 
    wire [6+WITH_CSR:0] waddr;
    wire [rf_width-1:0] wdata;
-   wire 	       wen;
+   wire                wen;
    wire [6+WITH_CSR:0] raddr;
    wire [rf_width-1:0] rdata;
 
@@ -152,19 +152,19 @@ module serving
 
    localparam RF_L2W = $clog2(rf_width);
 
-   wire 		   rf_wreq;
-   wire 		   rf_rreq;
+   wire                    rf_wreq;
+   wire                    rf_rreq;
    wire [$clog2(regs)-1:0] wreg0;
    wire [$clog2(regs)-1:0] wreg1;
-   wire 		   wen0;
-   wire 		   wen1;
-   wire 		   wdata0;
-   wire 		   wdata1;
+   wire                    wen0;
+   wire                    wen1;
+   wire                    wdata0;
+   wire                    wdata1;
    wire [$clog2(regs)-1:0] rreg0;
    wire [$clog2(regs)-1:0] rreg1;
-   wire 		   rf_ready;
-   wire 		   rdata0;
-   wire 		   rdata1;
+   wire                    rf_ready;
+   wire                    rdata0;
+   wire                    rdata1;
 
 
    serv_rf_ram_if

--- a/serving/serving_arbiter.v
+++ b/serving/serving_arbiter.v
@@ -23,23 +23,23 @@ module serving_arbiter
    input wire [31:0]  i_wb_cpu_dbus_adr,
    input wire [31:0]  i_wb_cpu_dbus_dat,
    input wire [3:0]   i_wb_cpu_dbus_sel,
-   input wire 	      i_wb_cpu_dbus_we,
-   input wire 	      i_wb_cpu_dbus_stb,
+   input wire         i_wb_cpu_dbus_we,
+   input wire         i_wb_cpu_dbus_stb,
    output wire [31:0] o_wb_cpu_dbus_rdt,
-   output wire 	      o_wb_cpu_dbus_ack,
+   output wire        o_wb_cpu_dbus_ack,
 
    input wire [31:0]  i_wb_cpu_ibus_adr,
-   input wire 	      i_wb_cpu_ibus_stb,
+   input wire         i_wb_cpu_ibus_stb,
    output wire [31:0] o_wb_cpu_ibus_rdt,
-   output wire 	      o_wb_cpu_ibus_ack,
+   output wire        o_wb_cpu_ibus_ack,
 
    output wire [31:0] o_wb_mem_adr,
    output wire [31:0] o_wb_mem_dat,
    output wire [3:0]  o_wb_mem_sel,
-   output wire 	      o_wb_mem_we,
-   output wire 	      o_wb_mem_stb,
+   output wire        o_wb_mem_we,
+   output wire        o_wb_mem_stb,
    input wire [31:0]  i_wb_mem_rdt,
-   input wire 	      i_wb_mem_ack);
+   input wire         i_wb_mem_ack);
 
    assign o_wb_cpu_dbus_rdt = i_wb_mem_rdt;
    assign o_wb_cpu_dbus_ack = i_wb_mem_ack & !i_wb_cpu_ibus_stb;

--- a/serving/serving_mux.v
+++ b/serving/serving_mux.v
@@ -19,34 +19,34 @@
 
 module serving_mux
   (
-   input wire 	      i_clk,
-   input wire 	      i_rst,
+   input wire         i_clk,
+   input wire         i_rst,
 
    input wire [31:0]  i_wb_cpu_adr,
    input wire [31:0]  i_wb_cpu_dat,
    input wire [3:0]   i_wb_cpu_sel,
-   input wire 	      i_wb_cpu_we,
-   input wire 	      i_wb_cpu_stb,
+   input wire         i_wb_cpu_we,
+   input wire         i_wb_cpu_stb,
    output wire [31:0] o_wb_cpu_rdt,
-   output wire 	      o_wb_cpu_ack,
+   output wire        o_wb_cpu_ack,
 
    output wire [31:0] o_wb_mem_adr,
    output wire [31:0] o_wb_mem_dat,
    output wire [3:0]  o_wb_mem_sel,
-   output wire 	      o_wb_mem_we,
-   output wire 	      o_wb_mem_stb,
+   output wire        o_wb_mem_we,
+   output wire        o_wb_mem_stb,
    input wire [31:0]  i_wb_mem_rdt,
-   input wire 	      i_wb_mem_ack,
+   input wire         i_wb_mem_ack,
 
    output wire [31:0] o_wb_ext_adr,
    output wire [31:0] o_wb_ext_dat,
    output wire [3:0]  o_wb_ext_sel,
-   output wire 	      o_wb_ext_we,
-   output wire 	      o_wb_ext_stb,
+   output wire        o_wb_ext_we,
+   output wire        o_wb_ext_stb,
    input wire [31:0]  i_wb_ext_rdt,
-   input wire 	      i_wb_ext_ack);
+   input wire         i_wb_ext_ack);
 
-   wire 	      ext = (i_wb_cpu_adr[31:30] != 2'b00);
+   wire               ext = (i_wb_cpu_adr[31:30] != 2'b00);
 
    assign o_wb_cpu_rdt = ext ? i_wb_ext_rdt : i_wb_mem_rdt;
    assign o_wb_cpu_ack = ext ? i_wb_ext_ack : i_wb_mem_ack;

--- a/serving/serving_ram.v
+++ b/serving/serving_ram.v
@@ -23,37 +23,37 @@ module serving_ram
     parameter depth = 256,
     parameter aw    = $clog2(depth),
     parameter memfile = "")
-   (input wire 		i_clk,
+   (input wire          i_clk,
     input wire [aw-1:0] i_waddr,
-    input wire [7:0] 	i_wdata,
-    input wire 		i_wen,
+    input wire [7:0]    i_wdata,
+    input wire          i_wen,
     input wire [aw-1:0] i_raddr,
-    output wire [7:0] 	o_rdata,
+    output wire [7:0]   o_rdata,
 
     input wire [aw-1:2] i_wb_adr,
-    input wire [31:0] 	i_wb_dat,
-    input wire [3:0] 	i_wb_sel,
-    input wire 		i_wb_we,
-    input wire 		i_wb_stb,
-    output wire [31:0] 	o_wb_rdt,
-    output reg 		o_wb_ack);
+    input wire [31:0]   i_wb_dat,
+    input wire [3:0]    i_wb_sel,
+    input wire          i_wb_we,
+    input wire          i_wb_stb,
+    output wire [31:0]  o_wb_rdt,
+    output reg          o_wb_ack);
 
-   reg [1:0] 		bsel;
+   reg [1:0]            bsel;
    reg [7:0] rdata;
 
-   wire 		wb_en = i_wb_stb & !i_wen & !o_wb_ack;
+   wire                 wb_en = i_wb_stb & !i_wen & !o_wb_ack;
 
-   wire 		wb_we = i_wb_we & i_wb_sel[bsel];
+   wire                 wb_we = i_wb_we & i_wb_sel[bsel];
 
-   wire  		we = wb_en ? wb_we : i_wen;
+   wire                 we = wb_en ? wb_we : i_wen;
 
-   reg [7:0] 		mem [0:depth-1] /* verilator public */;
+   reg [7:0]            mem [0:depth-1] /* verilator public */;
 
-   wire [aw-1:0] 	waddr = wb_en ? {i_wb_adr[aw-1:2],bsel} : i_waddr;
-   wire [7:0] 		wdata = wb_en ? i_wb_dat[bsel*8+:8]     : i_wdata;
-   wire [aw-1:0] 	raddr = wb_en ? {i_wb_adr[aw-1:2],bsel} : i_raddr;
+   wire [aw-1:0]        waddr = wb_en ? {i_wb_adr[aw-1:2],bsel} : i_waddr;
+   wire [7:0]           wdata = wb_en ? i_wb_dat[bsel*8+:8]     : i_wdata;
+   wire [aw-1:0]        raddr = wb_en ? {i_wb_adr[aw-1:2],bsel} : i_raddr;
 
-   reg [23:0] 		wb_rdt;
+   reg [23:0]           wb_rdt;
    assign o_wb_rdt = {rdata, wb_rdt};
 
    always @(posedge i_clk) begin
@@ -71,8 +71,8 @@ module serving_ram
 
    initial
      if(|memfile) begin
-	$display("Preloading %m from %s", memfile);
-	$readmemh(memfile, mem);
+        $display("Preloading %m from %s", memfile);
+        $readmemh(memfile, mem);
      end
 
    assign o_rdata = rdata;

--- a/sw/blinky.S
+++ b/sw/blinky.S
@@ -11,7 +11,7 @@
 #ifndef DELAY
 #define DELAY 0x100000 /* Loop 100000 times before inverting the LED */
 #endif
-	
+
 	/*
 	a0 = GPIO Base address
 	t0 = Value


### PR DESCRIPTION
* Expands all tabs (based on ts=8). There was a mix of both, creating
  weird alignement issues all over ... since space seemed to be more
  common in this repo, I expanded it all.

* Remove whitespaces at the end of line

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>