### PR TITLE
Add support for Terasic DE10 Nano Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ FPGA Pin D11 (Connector JP1, pin 38) is used for UART output with 57600 baud rat
 
     fusesoc run --target=de0_nano servant
 
+### DE10 Nano
+
+FPGA Pin Y15 (Connector JP7, pin 1) is used for UART output with 57600 baud rate. DE10 Nano needs an external 3.3V UART to connect to this pin
+
+    fusesoc run --target=de10_nano servant
+
 ### DECA development kit
 
 FPGA Pin W18 (Pin 3 P8 connector)  is used for UART output with 57600 baud rate. Key 0 is reset and Led 0 q output.

--- a/data/de10_nano.sdc
+++ b/data/de10_nano.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {i_clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/data/de10_nano.tcl
+++ b/data/de10_nano.tcl
@@ -1,0 +1,13 @@
+set_location_assignment PIN_V11 -to i_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_clk
+
+set_location_assignment PIN_W15 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q
+
+# GPIO0 Pin 1
+set_location_assignment PIN_Y15 -to uart_txd
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart_txd
+
+#KEY[0]
+set_location_assignment PIN_AH17 -to i_rst_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_rst_n

--- a/servant.core
+++ b/servant.core
@@ -69,6 +69,13 @@ filesets:
       - servant/servive_clock_gen.v : {file_type : verilogSource}
       - servant/servive.v : {file_type : verilogSource}
 
+  de10_nano:
+    files:
+      - data/de10_nano.sdc : {file_type : SDC}
+      - data/de10_nano.tcl : {file_type : tclSource}
+      - servant/servive_clock_gen.v : {file_type : verilogSource}
+      - servant/servive.v : {file_type : verilogSource}
+
   tinyfpga_bx: {files: [data/tinyfpga_bx.pcf : {file_type : PCF}]}
   icebreaker : {files: [data/icebreaker.pcf  : {file_type : PCF}]}
   icesugar   : {files: [data/icesugar.pcf : {file_type : PCF}]}
@@ -180,6 +187,18 @@ targets:
         family : Cyclone IV E
         device : EP4CE22F17C6
     toplevel: servive
+
+  de10_nano:
+    default_tool: quartus
+    description: Terasic DE10 Nano Kit
+    filesets : [mem_files, soc, de10_nano]
+    parameters : [memfile, memsize=32768]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSEBA6U23I7
+        board_device_index : 2
+    toplevel : servive
 
   icebreaker:
     default_tool : icestorm


### PR DESCRIPTION
Terasic DE10 Nano kit is a cycloneV SoC (5CSEBA6U23I7) based board