### PR TITLE
Add support for EBAZ4205 'Development' Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The FuseSoC standard library already contain a version of SERV, but if we want t
 
 `fusesoc library add serv https://github.com/olofk/serv`
 
-The SERV repo will now be available in $WORKSPACE/fusesoc_libraries/serv. To save some typing, we will refer to that directory as `$SERV`. 
+The SERV repo will now be available in $WORKSPACE/fusesoc_libraries/serv. To save some typing, we will refer to that directory as `$SERV`.
 
 We are now ready to do our first exercises with SERV
 
@@ -45,7 +45,7 @@ If everything worked, the output should look like
 
     INFO: Preparing ::serv:1.1.0
     INFO: Setting up project
-    
+
     INFO: Building simulation model
     INFO: Running
 
@@ -159,13 +159,24 @@ FPGA Pin Y15 (Connector JP7, pin 1) is used for UART output with 57600 baud rate
 
 ### DECA development kit
 
-FPGA Pin W18 (Pin 3 P8 connector)  is used for UART output with 57600 baud rate. Key 0 is reset and Led 0 q output.
+FPGA Pin W18 (Pin 3 P8 connector) is used for UART output with 57600 baud rate. Key 0 is reset and Led 0 q output.
 
     fusesoc run --target=deca servant
 
+### EBAZ4205 'Development' Board
+
+Pin B20 is used for UART output with 57600 baud rate. To use `blinky.hex`
+change B20 to W14 (red led) in `data/ebaz4205.xdc` file).
+
+    fusesoc run --target=ebaz4205 servant
+
+    fusesoc run --target=ebaz4205 servant --memfile=$SERV/sw/blinky.hex
+
+Reference: https://github.com/fusesoc/blinky#ebaz4205-development-board
+
 ### SoCKit development kit
 
-FPGA Pin F14 (HSTC GPIO addon connector J2, pin 2) is used for UART output with 57600 baud rate. 
+FPGA Pin F14 (HSTC GPIO addon connector J2, pin 2) is used for UART output with 57600 baud rate.
 
     fusesoc run --target=sockit servant
 

--- a/data/ebaz4205.xdc
+++ b/data/ebaz4205.xdc
@@ -1,0 +1,10 @@
+## 33.333 MHz Clock signal
+set_property -dict { PACKAGE_PIN N18 IOSTANDARD LVCMOS33 } [get_ports i_clk];
+create_clock -add -name sys_clk_pin -period 30.00 -waveform {0 5} [get_ports i_clk];
+
+## LED(s)
+# set_property -dict { PACKAGE_PIN W13 IOSTANDARD LVCMOS33 } [get_ports { q_green }];
+# set_property -dict { PACKAGE_PIN W14 IOSTANDARD LVCMOS33 } [get_ports { q }];
+
+## UART on DATA1_8 pin
+set_property -dict { PACKAGE_PIN B20 IOSTANDARD LVCMOS33 } [get_ports q];

--- a/servant.core
+++ b/servant.core
@@ -76,6 +76,12 @@ filesets:
       - servant/servive_clock_gen.v : {file_type : verilogSource}
       - servant/servive.v : {file_type : verilogSource}
 
+  ebaz4205:
+    files:
+      - servant/servix_ebaz4205_clock_gen.v : {file_type : verilogSource}
+      - servant/servix_ebaz4205.v : {file_type : verilogSource}
+      - data/ebaz4205.xdc : {file_type : xdc}
+
   tinyfpga_bx: {files: [data/tinyfpga_bx.pcf : {file_type : PCF}]}
   icebreaker : {files: [data/icebreaker.pcf  : {file_type : PCF}]}
   icesugar   : {files: [data/icesugar.pcf : {file_type : PCF}]}
@@ -182,7 +188,7 @@ targets:
         family : MAX 10
         device : 10M50DAF484C6GES
     toplevel: servive
-   
+
   de0_nano:
     default_tool : quartus
     filesets : [mem_files, soc, de0_nano]
@@ -295,6 +301,15 @@ targets:
     tools:
       vivado: {part : xc7a35ticsg324-1L}
     toplevel : servix
+
+  ebaz4205:
+    default_tool: vivado
+    description: EBAZ4205 'Development' Board
+    filesets : [mem_files, soc, ebaz4205]
+    parameters : [memfile, memsize, frequency=16]
+    tools:
+      vivado: {part : xc7z010clg400-1}
+    toplevel : servix_ebaz4205
 
   ac701:
     default_tool: vivado

--- a/servant/servix_ebaz4205.v
+++ b/servant/servix_ebaz4205.v
@@ -1,0 +1,30 @@
+`default_nettype none
+module servix_ebaz4205
+(
+ input wire  i_clk,
+ output wire q);
+
+   parameter frequency = 32;
+   parameter memfile = "zephyr_hello.hex";
+   parameter memsize = 8192;
+   parameter PLL = "NONE";
+
+   wire      wb_clk;
+   wire      wb_rst;
+
+   servix_ebaz4205_clock_gen
+     #(.frequency (frequency))
+   clock_gen
+     (.i_clk (i_clk),
+      .o_clk (wb_clk),
+      .o_rst (wb_rst));
+
+   servant
+     #(.memfile (memfile),
+       .memsize (memsize))
+   servant
+     (.wb_clk (wb_clk),
+      .wb_rst (wb_rst),
+      .q      (q));
+
+endmodule

--- a/servant/servix_ebaz4205_clock_gen.v
+++ b/servant/servix_ebaz4205_clock_gen.v
@@ -1,0 +1,40 @@
+`default_nettype none
+module servix_ebaz4205_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   parameter frequency = 32;
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   // (33.333 * 48) / 50 => 31.9996 MHz
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(48),
+       .CLKIN1_PERIOD(30.000300003), // 33.333 MHz
+       .CLKOUT0_DIVIDE((frequency == 32) ? 50 : 100),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule


### PR DESCRIPTION
References:

- https://github.com/fusesoc/blinky/pull/68/files (EBAZ4205 blinky)
- https://github.com/fusesoc/blinky#ebaz4205-development-board
- Existing 'arty_a7_35t' example

This PR also cleans up a bunch of whitespace issues (no functional change).

Picture:

![Screenshot_2021-08-13_00-20-28](https://user-images.githubusercontent.com/79528/129252306-f78ae3dd-2626-4d99-83d7-df28d7705c28.png)
