### PR TITLE
Vars modelsim

### DIFF
--- a/rtl/serv_decode.v
+++ b/rtl/serv_decode.v
@@ -77,6 +77,12 @@ generate
    wire co_mem_word;
    wire co_rd_alu_en;
 
+   //opcode
+   wire op_or_opimm = (!opcode[4] & opcode[2] & !opcode[0]);
+
+   wire co_mem_op   = !opcode[4] & !opcode[2] & !opcode[0];
+   wire co_branch_op = opcode[4] & !opcode[2];
+
    if (MDU) begin
       assign co_mdu_op     = ((opcode == 5'b01100) & imm25);
       assign co_shift_op   = op_or_opimm & (funct3[1:0] == 2'b01) & !co_mdu_op;
@@ -92,12 +98,6 @@ generate
    end
    assign co_ext_funct3 = funct3;
 endgenerate
-
-   //opcode
-   wire op_or_opimm = (!opcode[4] & opcode[2] & !opcode[0]);
-
-   wire co_mem_op   = !opcode[4] & !opcode[2] & !opcode[0];
-   wire co_branch_op = opcode[4] & !opcode[2];
 
    //jal,branch =     imm
    //jalr       = rs1+imm

--- a/rtl/serv_immdec.v
+++ b/rtl/serv_immdec.v
@@ -28,7 +28,6 @@ module serv_immdec
    reg [4:0]  imm24_20;
    reg [4:0]  imm11_7;
 
-   assign o_imm = i_cnt_done ? signbit : i_ctrl[0] ? imm11_7[0] : imm24_20[0];
    assign o_csr_imm = imm19_12_20[4];
 
    generate
@@ -88,5 +87,7 @@ module serv_immdec
 	 end
       end
    endgenerate
+
+	 assign o_imm = i_cnt_done ? signbit : i_ctrl[0] ? imm11_7[0] : imm24_20[0];
 	 
 endmodule

--- a/rtl/serv_top.v
+++ b/rtl/serv_top.v
@@ -121,6 +121,8 @@ module serv_top
    wire 	 bufreg_imm_en;
    wire 	 bufreg_clr_lsb;
    wire 	 bufreg_q;
+   wire [31:0] dbus_rdt;
+   wire        dbus_ack;
 
    wire          alu_sub;
    wire [1:0] 	 alu_bool_op;
@@ -553,8 +555,6 @@ module serv_top
 `endif
 
 generate
-   wire [31:0] dbus_rdt;
-   wire        dbus_ack;
   if (MDU) begin
     assign dbus_rdt = i_ext_ready ? i_ext_rd:i_dbus_rdt;
     assign dbus_ack = i_dbus_ack | i_ext_ready;


### PR DESCRIPTION
Update the files to fix issue #62 .

```
Modelsim tends to get quite angry when it sees a variable that is not declared.

serv_decode.v: "op_or_opimm"
serv_immdec.v: "signbit"
serv_top.v: "dbus_rdt"
```