### PR TITLE
Add AX309 board as a target running at 32MHz by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ Pin 56 is used as the GPIO output which is connected to the board's LED1. Due to
     fusesoc run --target=go_board servant
     iceprog build/servant_1.1.0/go_board-icestorm/servant_1.1.0.bin
 
+### Alinx ax309 (Spartan6 LX9)
+
+Pin D12 (the on-board RS232 TX pin) is used for UART output with 115200 baud rate and wired to Pin P4 (LED0).
+
+    fusesoc run --target=ax309 servant
+
 ## Other targets
 
 The above targets are run on the servant SoC, but there are some targets defined for the CPU itself. Verilator can be run in lint mode to check for design problems by running

--- a/data/ax309.ucf
+++ b/data/ax309.ucf
@@ -1,0 +1,9 @@
+CONFIG VCCAUX=3.3;
+
+NET i_clk     LOC = T8  | IOSTANDARD = LVCMOS33;
+NET i_rst     LOC = L3  | IOSTANDARD = LVCMOS33;
+NET q         LOC = P4  | IOSTANDARD = LVCMOS33;
+NET o_uart_tx LOC = D12 | IOSTANDARD = LVCMOS33;
+
+NET i_clk TNM_NET = sys_clk_pin;
+TIMESPEC TS_USER_CLOCK = PERIOD sys_clk_pin 50000 kHz;

--- a/servant.core
+++ b/servant.core
@@ -104,6 +104,12 @@ filesets:
       - data/go_board.pcf : {file_type : PCF}
       - servant/service_go_board.v : {file_type : verilogSource}
 
+  ax309:
+    files:
+      - servant/servant_ax309_clock_gen.v : {file_type : verilogSource}
+      - servant/servant_ax309.v : {file_type : verilogSource}
+      - data/ax309.ucf : {file_type : UCF}
+
   lx9_microboard:
     files:
       - servant/servant_lx9_clock_gen.v : {file_type : verilogSource}
@@ -269,6 +275,19 @@ targets:
         package : csg324
         speed   : -2
     toplevel : servant_lx9
+
+  ax309:
+    default_tool : ise
+    description : XILINX Spartan-6 XC6SLX9 FPGA Development Board
+    filesets : [mem_files, soc, ax309]
+    parameters : [memfile, memsize]
+    tools:
+      ise:
+        family  : Spartan6
+        device  : xc6slx9
+        package : ftg256
+        speed   : -3
+    toplevel : servant_ax309
 
   tinyfpga_bx:
     default_tool : icestorm

--- a/servant/servant_ax309.v
+++ b/servant/servant_ax309.v
@@ -1,0 +1,32 @@
+`default_nettype none
+module servant_ax309
+(
+ input wire  i_clk,
+ input wire  i_rst,
+ output wire o_uart_tx,
+ output wire q);
+
+   parameter memfile = "zephyr_hello.hex";
+   parameter memsize = 8192;
+
+   wire      wb_clk;
+   wire      wb_rst;
+
+   assign o_uart_tx = q;
+
+   servant_ax309_clock_gen
+   clock_gen
+     (.i_clk (i_clk),
+      .i_rst (i_rst),
+      .o_clk (wb_clk),
+      .o_rst (wb_rst));
+
+   servant
+     #(.memfile (memfile),
+       .memsize (memsize))
+   servant
+     (.wb_clk (wb_clk),
+      .wb_rst (wb_rst),
+      .q      (q));
+
+endmodule

--- a/servant/servant_ax309_clock_gen.v
+++ b/servant/servant_ax309_clock_gen.v
@@ -1,0 +1,35 @@
+`default_nettype none
+module servant_ax309_clock_gen
+  (input wire  i_clk,
+   input wire  i_rst,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLL_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN_PERIOD(20.0), //50MHz
+       .CLKOUT1_DIVIDE(25), //32MHz
+       .DIVCLK_DIVIDE(1))
+   PLL_BASE_inst
+     (.CLKOUT1(o_clk),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN(i_clk),
+      .RST(~i_rst),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule


### PR DESCRIPTION
The UCF file and `servant_ax309*.v` are based on the ones from `servant_lx9*.v`, with the following functionalities:

- running at 32MHz instead of 16MHz;
- hence supporting a 115200 baud rate UART by the on-board RS232 (USB power+UART);
- the on-board `RESET` button can reset the CPU.