### PR TITLE
ice40_pll.v - Guarantee at least 2 cycles of o_rst after PLL locked.

### DIFF
--- a/servant/ice40_pll.v
+++ b/servant/ice40_pll.v
@@ -11,8 +11,8 @@ module ice40_pll
 
    reg [1:0] rst_reg;
    always @(posedge o_clk)
-     rst_reg <= {!locked, rst_reg[1]};
-   assign o_rst = rst_reg[0];
+     rst_reg <= {rst_reg[0],locked};
+   assign o_rst = ~rst_reg[1];
 
    generate
       if (PLL == "ICE40_CORE") begin


### PR DESCRIPTION
While helping gojimmypi to bring up FuseSOC Serv on a new ice40-based target we were having trouble with Serv not starting up after configuration. Digging into the clock and reset logic I discovered that the wb_rst signal generated in the ice40_pll.v module was not asserting during start up.

The existing circuit relies on the PLL lock signal to clear the reset after two clock cycles, but because the initial state of the two delay registers defaults to logic 0, the reset signal is not guaranteed to ever assert. By inverting the input and output of the 2-stage register pipeline we can ensure that at least two cycles of logic '1' are generated, thus providing a usable reset.

This change has been verified working on the icebreaker target and also on the new ice-v-wireless target that we're working on.

NOTE - the verilator-based CI script that's part of the serv repo appears to be broken so that has been failing for me lately.