### PR TITLE
Add Arty S7-50 support

### DIFF
--- a/data/arty_s7_50t.xdc
+++ b/data/arty_s7_50t.xdc
@@ -1,0 +1,10 @@
+set_property -dict { PACKAGE_PIN R2  IOSTANDARD SSTL135  } [get_ports i_clk];   #IO_L12P_T1_MRCC_34 Sch=ddr3_clk[200]
+set_property -dict { PACKAGE_PIN C18 IOSTANDARD LVCMOS33 } [get_ports i_rst_n]; #IO_L11N_T1_SRCC_15
+
+set_property -dict { PACKAGE_PIN R12 IOSTANDARD LVCMOS33 } [get_ports q];       #IO_25_14 Sch=uart_rxd_out
+#set_property -dict { PACKAGE_PIN E18 IOSTANDARD LVCMOS33 } [get_ports q];       #IO_L16N_T2_A27_15 Sch=led[2]
+
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];

--- a/doc/servant.rst
+++ b/doc/servant.rst
@@ -45,6 +45,14 @@ blinky.hex change D10 to H5 (led[4]) in data/arty_a7_35t.xdc).
 
     fusesoc run --target=arty_a7_35t servant
 
+Arty S7 50T
+^^^^^^^^^^^
+
+Pin R12 (uart_rxd_out) is used for UART output with 57600 baud rate (to use
+blinky.hex change R12 to E18 (led[4]) in data/arty_s7_50t.xdc).
+
+    fusesoc run --target=arty_s7_50t servant
+
 Chameleon96 (Arrow 96 CV SoC Board)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/servant.core
+++ b/servant.core
@@ -60,6 +60,12 @@ filesets:
       - servant/servix.v : {file_type : verilogSource}
       - data/arty_a7_35t.xdc : {file_type : xdc}
 
+  arty_s7_50t:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/arty_s7_50t.xdc : {file_type : xdc}
+
   ax309:
     files:
       - servant/servant_ax309_clock_gen.v : {file_type : verilogSource}
@@ -215,6 +221,14 @@ targets:
     parameters : [memfile, memsize, frequency=16, "mdu? (MDU=1)", WITH_RESET]
     tools:
       vivado: {part : xc7a35ticsg324-1L}
+    toplevel : servix
+
+  arty_s7_50t:
+    default_tool: vivado
+    filesets : [mem_files, soc, arty_s7_50t]
+    parameters : [memfile, memsize, frequency=16, "mdu? (MDU=1)", WITH_RESET]
+    tools:
+      vivado: {part : xc7s50csga324-1}
     toplevel : servix
 
   ax309:


### PR DESCRIPTION
Add Servant support for the [Digilent Arty S7-50](https://digilent.com/reference/programmable-logic/arty-s7/start) based on existing Arty A7-35 implementation.

# Testing

### Hello

```sh
$ fusesoc run --target=arty_s7_50t servant --memfile=$SERV/sw/zephyr_hello.hex
...
INFO: SUCCESS! FPGA xc7s50csga324-1 successfully programmed with bitstream servant_1.2.1.bit.
```
```sh
$ sudo picocom /dev/ttyUSB1 --baud=57600
...
***** Booting Zephyr OS zephyr-v1.14.1-4-gc7c2d62513fe *****
Hello World! service
```

### Blinky

```diff
$ git diff
diff --git a/data/arty_s7_50t.xdc b/data/arty_s7_50t.xdc
index 30e799b..8c823a5 100644
--- a/data/arty_s7_50t.xdc
+++ b/data/arty_s7_50t.xdc
@@ -1,7 +1,7 @@
 set_property -dict { PACKAGE_PIN R2  IOSTANDARD SSTL135  } [get_ports i_clk];   #IO_L12P_T1_MRCC_34 Sch=ddr3_clk[200]
 set_property -dict { PACKAGE_PIN C18 IOSTANDARD LVCMOS33 } [get_ports i_rst_n]; #IO_L11N_T1_SRCC_15
 
-set_property -dict { PACKAGE_PIN R12 IOSTANDARD LVCMOS33 } [get_ports q];       #IO_25_14 Sch=uart_rxd_out
+set_property -dict { PACKAGE_PIN E18 IOSTANDARD LVCMOS33 } [get_ports q];       #IO_L16N_T2_A27_15 Sch=led[2]
```
```sh
$ fusesoc run --target=arty_s7_50t servant --memfile=$SERV/sw/blinky.hex
...
```
LED 2 (LD2) began toggling every ~7 seconds.

# References

* https://github.com/Digilent/digilent-xdc/blob/master/Arty-S7-50-Master.xdc