### PR TITLE
Make serv_alu.v synthesizable with Vivado

### DIFF
--- a/rtl/serv_alu.v
+++ b/rtl/serv_alu.v
@@ -60,7 +60,7 @@ module serv_alu
 
    assign result_slt[0] = cmp_r & i_cnt0;
    generate
-      if (W>1) assign result_slt[B:1] = '0;
+      if (W>1) assign result_slt[B:1] = {B{1'b0}};
    endgenerate
 
    assign o_rd = i_buf |


### PR DESCRIPTION
Currently, `serv_alu.v` uses the one-bit unsized literal `'0` which Vivado doesn't support unless a `.sv` file extension is used.

To recreate the error, run `fusesoc run --tool=vivado serv --pnr=none --part=xc7a100tcsg324-1`. Synthesis should terminate with an error.

This change resolves the Xilinx synthesis error.