### PR TITLE
add support for machdyne kolibri

### DIFF
--- a/data/machdyne_kolibri.pcf
+++ b/data/machdyne_kolibri.pcf
@@ -1,0 +1,4 @@
+set_io clk48	G1
+set_io led		B11
+set_io tx		B1
+set_io rx		B2

--- a/doc/servant.rst
+++ b/doc/servant.rst
@@ -133,6 +133,15 @@ Pin 9 is used for UART output with 57600 baud rate.
 
     iceprog build/servant_1.2.1/icestick-icestorm/servant_1.2.1.bin
 
+Machdyne Kolibri
+^^^^^^^^^^^^^^^^
+
+Pin B1 is used for UART output with 115200 baud rate. The serial port on Kolibri is accessible as a USB-CDC device.
+
+    fusesoc run --target=machdyne_kolibri servant
+
+    ldprog -Ks build/servant_1.2.1/machdyne_kolibri-icestorm/servant_1.2.1.bin
+
 Nandland Go Board
 ^^^^^^^^^^^^^^^^^
 

--- a/servant.core
+++ b/servant.core
@@ -142,6 +142,11 @@ filesets:
       - servant/servant_lx9.v : {file_type : verilogSource}
       - data/lx9_microboard.ucf : {file_type : UCF}
 
+  machdyne_kolibri:
+    files:
+      - servant/servant_md_kolibri.v : {file_type : verilogSource}
+      - data/machdyne_kolibri.pcf : {file_type : PCF}
+
   nexys_2:
     files:
       - servant/servax_clock_gen.v : {file_type : verilogSource}
@@ -398,6 +403,18 @@ targets:
         package : csg324
         speed   : -2
     toplevel : servant_lx9
+
+  machdyne_kolibri:
+    default_tool: icestorm
+    description : Machdyne Kolibri FPGA Dongle
+    filesets : [mem_files, soc, machdyne_kolibri]
+    parameters : [memfile, memsize]
+    tools:
+    tools:
+      icestorm:
+        nextpnr_options : [--hx4k, --package, bg121, --freq, 48]
+        pnr: next
+    toplevel : servant_md_kolibri
 
   nexys_2_500:
     default_tool: ise

--- a/servant/servant_md_kolibri.v
+++ b/servant/servant_md_kolibri.v
@@ -1,0 +1,46 @@
+// based on servant_upduino2.v
+
+`default_nettype none
+module servant_md_kolibri
+  (
+   input wire clk48,
+   output wire led,
+   output wire tx);
+
+   parameter memfile = "zephyr_hello.hex";
+   parameter memsize = 8192;
+
+   wire        clk32;
+   wire        locked;
+
+   reg         rst = 1'b1;
+
+   // 48MHz -> 32MHz
+	SB_PLL40_CORE #(
+      .FEEDBACK_PATH("SIMPLE"),
+      .DIVR(4'b0010),        // DIVR =  2
+      .DIVF(7'b0111111),     // DIVF = 63
+      .DIVQ(3'b101),         // DIVQ =  5
+      .FILTER_RANGE(3'b001)  // FILTER_RANGE = 1
+   ) uut (
+      .LOCK(locked),
+      .RESETB(1'b1),
+      .BYPASS(1'b0),
+      .REFERENCECLK(clk48),
+      .PLLOUTCORE(clk32)
+   );
+
+   always @(posedge clk32)
+     rst <= !locked;
+
+   servant
+     #(.memfile (memfile),
+       .memsize (memsize))
+   servant
+     (.wb_clk (clk32),
+      .wb_rst (rst),
+      .q      (tx));
+
+	assign led = tx;
+
+endmodule


### PR DESCRIPTION
This PR adds servant support for the Kolibri FPGA dongle:

https://github.com/machdyne/kolibri