### PR TITLE
Support for Alchitry Au platform

### DIFF
--- a/data/alchitry_au.xdc
+++ b/data/alchitry_au.xdc
@@ -1,0 +1,16 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN N14 IOSTANDARD LVCMOS33 } [get_ports i_clk];
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];
+
+## Reset
+set_property -dict {PACKAGE_PIN P6  IOSTANDARD LVCMOS33 } [get_ports i_rst_n];
+
+## LED
+## set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports q];
+
+## USB Serial output
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports q]
+
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+

--- a/servant.core
+++ b/servant.core
@@ -55,6 +55,12 @@ filesets:
 
   alhambra   : {files: [data/alhambra.pcf : {file_type : PCF}]}
 
+  alchitry_au:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/alchitry_au.xdc : {file_type : xdc}
+
   arty_a7_35t:
     files:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
@@ -214,6 +220,15 @@ targets:
     tools:
       vivado: {part : xc7a200t-fbg676-2}
     toplevel : servant_ac701
+
+  alchitry_au:
+    default_tool: vivado
+    description: Open-hardware Alchitry AU FPGA board
+    filesets : [mem_files, soc, alchitry_au]
+    parameters : [memfile, memsize, frequency=16, "mdu? (MDU=1)", WITH_RESET]
+    tools:
+      vivado: {part : xc7a35tftg256-1}
+    toplevel : servix
 
   alhambra:
     default_tool : icestorm


### PR DESCRIPTION
Add Servant support for [Alchitry Au](https://www.sparkfun.com/products/16527) platform.

### Testing
```
$ fusesoc core show servant
CORE INFO
Name:        ::servant:1.2.1
Description: <No description>
Core root:   fusesoc_libraries/serv
Core file:   servant.core
Targets:
alchitry_au         : Open-hardware Alchitry AU FPGA board
. . .
$
```

### Build bistream
```
fusesoc run --target=alchitry_au servant --uart_baudrate=57600 --memfile ./fusesoc_libraries/serv/sw/zephyr_hello.hex

. . .
Creating bitstream...
Writing bitstream ./servix.bit...
Writing bitstream ./servix.bin...

Bitstream generation completed
INFO: [Common 17-206] Exiting Vivado at Fri Jun 14 16:49:54 2024...
$

```

### Test bitstream

```
$ sudo picocom /dev/ttyUSB1 --baud=57600
picocom v3.1
Terminal ready
***** Booting Zephyr OS zephyr-v1.14.1-4-gc7c2d62513fe *****
Hello World! service
```

### Resources used
```
+----------------------------+------+-------+------------+-----------+-------+
|          Site Type         | Used | Fixed | Prohibited | Available | Util% |
+----------------------------+------+-------+------------+-----------+-------+
| Slice LUTs                 |  244 |     0 |          0 |     20800 |  1.17 |
|   LUT as Logic             |  243 |     0 |          0 |     20800 |  1.17 |
|   LUT as Memory            |    1 |     0 |          0 |      9600 |  0.01 |
|     LUT as Distributed RAM |    0 |     0 |            |           |       |
|     LUT as Shift Register  |    1 |     0 |            |           |       |
| Slice Registers            |  238 |     0 |          0 |     41600 |  0.57 |
|   Register as Flip Flop    |  238 |     0 |          0 |     41600 |  0.57 |
|   Register as Latch        |    0 |     0 |          0 |     41600 |  0.00 |
| F7 Muxes                   |    3 |     0 |          0 |     16300 |  0.02 |
| F8 Muxes                   |    0 |     0 |          0 |      8150 |  0.00 |
+----------------------------+------+-------+------------+-----------+-------+
```


