### PR TITLE
added support for MAX10 10M08 Evaluation Kit

### DIFF
--- a/data/max10_10m08evk.sdc
+++ b/data/max10_10m08evk.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {i_clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/data/max10_10m08evk.tcl
+++ b/data/max10_10m08evk.tcl
@@ -1,0 +1,24 @@
+#MAX10_CLK2_50  3.3V
+set_location_assignment PIN_27 -to i_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_clk
+
+#LED[0]
+set_location_assignment PIN_132 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q
+
+#P8 3 ARDUINO_IO1   
+set_location_assignment PIN_75 -to uart_txd
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart_txd
+
+#KEY[0]
+set_location_assignment PIN_121 -to i_rst_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_rst_n
+
+#  Configuration mode that allows Memory Initialisation
+set_global_assignment -name INTERNAL_FLASH_UPDATE_MODE "SINGLE IMAGE WITH ERAM"
+
+# Generate SVF File for openFPGALoader
+set_global_assignment -name GENERATE_SVF_FILE ON
+# set_global_assignment -name GENERATE_JBC_FILE ON
+set_global_assignment -name GENERATE_JAM_FILE ON
+

--- a/doc/servant.rst
+++ b/doc/servant.rst
@@ -183,6 +183,13 @@ Pin B1 is used for UART output with 115200 baud rate. The serial port on Kolibri
 
     ldprog -Ks build/servant_1.2.1/machdyne_kolibri-icestorm/servant_1.2.1.bin
 
+MAX10 10M08 Evaluation Kit
+^^^^^^^^^^^^^^^^^^^^
+
+FPGA Pin 75 (Arduino_IO01 J5 pin 7) is used for UART output with 57600 baud rate. SW1 is reset and Led 1 q output.
+
+    fusesoc run --target=max10_10m08evk servant
+
 Nandland Go Board
 ^^^^^^^^^^^^^^^^^
 

--- a/servant.core
+++ b/servant.core
@@ -172,6 +172,13 @@ filesets:
       - servant/servant_md_kolibri.v : {file_type : verilogSource}
       - data/machdyne_kolibri.pcf : {file_type : PCF}
 
+  max10_10m08evk:
+    files:
+      - data/max10_10m08evk.sdc : {file_type : SDC}
+      - data/max10_10m08evk.tcl : {file_type : tclSource}
+      - servant/servive_clock_gen.v : {file_type : verilogSource}
+      - servant/servive.v : {file_type : verilogSource}
+
   nexys_2:
     files:
       - servant/servax_clock_gen.v : {file_type : verilogSource}
@@ -472,6 +479,19 @@ targets:
         pnr: next
     toplevel : servant_md_kolibri
 
+  max10_10m08evk:
+    default_tool : quartus
+    description: MAX10 10M08 evaluation kit
+    hooks:
+      post_run: [jbc]
+    filesets : [mem_files, soc, max10_10m08evk]
+    parameters : [memfile, memsize]
+    tools:
+      quartus:
+        family : MAX 10
+        device : 10M08SAE144C8G
+    toplevel: servive
+
   nexys_2_500:
     default_tool: ise
     filesets : [mem_files, soc, nexys_2]
@@ -719,3 +739,8 @@ parameters:
 generate:
   ice40pll:
     generator: icepll
+
+scripts:
+  jbc:
+    cmd : [quartus_jbcc, "-n", servant_1_2_1_pof.jam, servant_1_2_1_pof.jbc]
+


### PR DESCRIPTION
This commit adds support for the MAX10 10M08 Evaluation Kit
It is functional and tested on hardware (hello world message appears on TX output)
Any way to get this approved/posted in time for Teardown (June 21st)?