### PR TITLE
Adding support for the iceFUN board

### DIFF
--- a/data/icefun.pcf
+++ b/data/icefun.pcf
@@ -1,0 +1,31 @@
+# For iceFUN board
+
+# 12 MHz clock
+set_io 	i_clk	P7
+
+# RS232
+set_io 	q 	C10
+
+#set_io --warn-no-port led1	 	C10
+#set_io --warn-no-port led2 		A10
+#set_io --warn-no-port led3 		D7
+#set_io --warn-no-port led4 		D6
+#set_io --warn-no-port led5	 	A7
+#set_io --warn-no-port led6	 	C7
+#set_io --warn-no-port led7	 	A4
+#set_io --warn-no-port led8	 	C4
+#set_io --warn-no-port lcol1		A12
+#set_io --warn-no-port lcol2	 	D10
+#set_io --warn-no-port lcol3 	A6
+#set_io --warn-no-port lcol4 	C5
+#set_io --warn-no-port spkp  	M12
+#set_io --warn-no-port spkm  	M6
+#set_io --warn-no-port key1  	C11
+#set_io --warn-no-port key2  	C6
+#set_io --warn-no-port key3  	A11
+#set_io --warn-no-port key4  	A5
+#set_io --warn-no-port red 		P14
+#set_io --warn-no-port green  	N14
+#set_io --warn-no-port blue  	L14
+#
+#set_io --warn-no-port clk12MHz	P7

--- a/servant.core
+++ b/servant.core
@@ -151,6 +151,8 @@ filesets:
       - servant/service_go_board.v : {file_type : verilogSource}
 
   icebreaker : {files: [data/icebreaker.pcf  : {file_type : PCF}]}
+  
+  icefun     : {files: [data/icefun.pcf  : {file_type : PCF}]}
 
   icestick   : {files: [data/icestick.pcf  : {file_type : PCF}]}
 
@@ -410,6 +412,18 @@ targets:
         pnr: next
     toplevel : service
 
+  icefun:
+    default_tool : icestorm
+    description: Devantech IceFUN
+    filesets : [mem_files, soc, service, icefun]
+    generate: [ice40pll : {freq_out : 16}]
+    parameters : [memfile, memsize, PLL=ICE40_CORE]
+    tools:
+      icestorm:
+        nextpnr_options: [--hx8k, --package, cb132 --freq, 16]
+        pnr: next
+    toplevel : service
+  
   icestick:
     default_tool : icestorm
     description: Lattice iCEstick


### PR DESCRIPTION
I'm working to get a servant running on an [iceFUN board](https://www.robotshop.com/products/icefun-fpga-board).

The changes I have made here allow me to run the following command without errors to give code I can upload to my device. 

```fusesoc run --target=icefun --tool=icestorm servant --pnr=next```

I have noticed that icestick and icebreaker also give similar errors relating to PLLs.

It would be nice to expand this so that a simple example (e.g. zephyr_phil) can be run on the board easily in one line as a demo.