### PR TITLE
Update to Zephyr 3.7.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -5,5 +5,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.5.0
+      revision: v3.7.0
       import: true

--- a/zephyr/soc/riscv/servant/CMakeLists.txt
+++ b/zephyr/soc/riscv/servant/CMakeLists.txt
@@ -4,4 +4,5 @@
 zephyr_sources(
     soc_irq.S
     vector.S
+    cpu_idle.c
     irq.c)

--- a/zephyr/soc/riscv/servant/cpu_idle.c
+++ b/zephyr/soc/riscv/servant/cpu_idle.c
@@ -1,0 +1,22 @@
+#include <zephyr/irq.h>
+#include <zephyr/tracing/tracing.h>
+
+// Override arch_cpu_idle() and arch_cpu_atomic_idle() to prevent insertion
+// of `wfi` instructions, which lock up our system. This was introduced in
+// Zephyr 3.6.0 with commit 5fb6e267f629dedb8382da6bcad8018b1bb8930a.
+//
+// This is probably a hardware bug in SERV. This issue is tracked as #131.
+// https://github.com/olofk/serv/issues/131
+
+void arch_cpu_idle(void)
+{
+	sys_trace_idle();
+	irq_unlock(MSTATUS_IEN);
+}
+
+void arch_cpu_atomic_idle(unsigned int key)
+{
+	sys_trace_idle();
+	irq_unlock(key);
+}
+


### PR DESCRIPTION
Hi,

this PR upgrades Zephyr to 3.7.0 by updating `west.yml`. It also works around an issue introduced with Zephyr 3.6.0 regarding the use of `wfi`. This issue is tracked as #131.

Cheers!
Markus

PS: This also seems to fix https://github.com/olofk/serv/issues/113. At least, I can now run the `philosophers` demo without issues.