### PR TITLE
Remove duplicate `tools` entry in servant.core

### DIFF
--- a/servant.core
+++ b/servant.core
@@ -491,7 +491,6 @@ targets:
     filesets : [mem_files, soc, machdyne_kolibri]
     parameters : [memfile, memsize]
     tools:
-    tools:
       icestorm:
         nextpnr_options : [--hx4k, --package, bg121, --freq, 48]
         pnr: next


### PR DESCRIPTION
In `servant.core`:`targets`:`machdyne_kolibri`