### PR TITLE
Add iCESugar-nano board

### DIFF
--- a/data/icesugar_nano.pcf
+++ b/data/icesugar_nano.pcf
@@ -1,0 +1,9 @@
+# 12 MHz external clock
+set_io i_clk        D1
+
+# LED
+set_io o_led        B6
+
+# UART
+set_io i_uart_rx    A3
+set_io o_uart_tx    B3

--- a/doc/servant.rst
+++ b/doc/servant.rst
@@ -155,6 +155,19 @@ serial console will show up.
 
     fusesoc run --target=icesugar servant
 
+iCESugar-nano
+^^^^^^^^^^^^^
+
+Pin B3 is used for LED output. As the default clock of 12 MHz is rather slow
+the LED only toggles every 9 seconds with the default blinky example.
+
+Thanks to the onboard debugger, you can just connect the USB Type-C connector
+to the PC, and a serial console will show up. However, the device doesn't have
+enough RAM to run the Zephyr hello-world example so the UART pins are not
+connect but they are defined in the PCF for easy reference.
+
+    fusesoc run --target=icesugar-nano servant
+
 ICE-V Wireless
 ^^^^^^^^^^^^^^
 

--- a/servant.core
+++ b/servant.core
@@ -157,6 +157,11 @@ filesets:
 
   icesugar   : {files: [data/icesugar.pcf : {file_type : PCF}]}
 
+  icesugar_nano:
+    files:
+      - data/icesugar_nano.pcf : {file_type : PCF}
+      - servant/servant_ice40_cm36.v : {file_type : verilogSource}
+
   icev_wireless : {files: [data/icev_wireless.pcf  : {file_type : PCF}]}
 
   gmm7550:
@@ -440,6 +445,17 @@ targets:
         nextpnr_options: [--up5k, --package, sg48, --freq, 32]
         pnr: next
     toplevel : service
+
+  icesugar-nano:
+    default_tool : icestorm
+    description : iCE40LP1K Development Board by MuseLab
+    filesets : [mem_files, soc, icesugar_nano]
+    parameters : [memfile=blinky.hex, memsize=7168]
+    tools:
+      icestorm:
+        nextpnr_options: [--lp1k, --package, cm36, --freq, 12]
+        pnr: next
+    toplevel : servant_ice40_cm36
 
   icev_wireless:
     default_tool : icestorm

--- a/servant/servant_ice40_cm36.v
+++ b/servant/servant_ice40_cm36.v
@@ -1,0 +1,41 @@
+`default_nettype none
+module servant_ice40_cm36 (
+    input  wire i_clk,
+    output wire o_led
+);
+
+  parameter memfile = "blinky.hex";
+  parameter memsize = 7168;
+
+  wire wb_clk;
+  reg  wb_rst;
+
+  /* iCE40 CM36 has no PLL. Drive everything from the external clock. */
+  assign wb_clk = i_clk;
+
+  /* Board has no button that can be used for reset, but blinky doesn't
+   * work at all if the reset isn't enabled for at least 25 clocks.
+   *
+   * This will generate a reset signal at power on.
+   */
+  reg [7:0] rst_cnt = '0;
+
+  always @(posedge i_clk) begin
+    if (rst_cnt < 255) begin
+      rst_cnt <= rst_cnt + 1;
+      wb_rst  <= 1;
+    end else begin
+      wb_rst <= 0;
+    end
+  end
+
+  servant #(
+      .memfile(memfile),
+      .memsize(memsize)
+  ) servant (
+      .wb_clk(wb_clk),
+      .wb_rst(wb_rst),
+      .q     (o_led)
+  );
+
+endmodule


### PR DESCRIPTION
Follow the 6 steps to add support for a new target.

Step 1: Locate input and output pins.

Step 2: Add pin constraint file. This covers clock input, LED and UART
        output.

Step 3: Create a clock generator. The chip has no internal clock
        generator so the external 12 MHz clock is used.

Step 4: Add top level servant_ice40_cm36 which connects the one-wire
        output of servant to both the LED and UART pin.

Step 5: Add fileset including the new top level and pin constraints.

Step 6: Add target icesugar-nano.

I would expect this to be it, but the LED is not blinking.

If I add a reset function, something like 5 seconds in reset, 5 seconds run time. No blinking LED.
Setting a ~1 second reset each 10 seconds, still no light.

Debugging with a single LED as output I must say, it's pretty hard. If I drive the LED from the top-level scope or mix my debug signal with the servant's 'q' output, the LED is blinking according to the debug signal just fine, but only driving the LED from the servant output makes no light.