### PR TITLE
docs: Fix missing space after comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each of the following commands should be run from the workspace directory:
     MDU will be available in `$WORKSPACE/fusesoc_libraries/mdu`
   
 
-:green_book: We are now ready to do our first exercises with SERV. If everything above is done correctly,we can use Verilator as a linter to check the SERV source code.
+:green_book: We are now ready to do our first exercises with SERV. If everything above is done correctly, we can use Verilator as a linter to check the SERV source code.
 
     $ fusesoc run --target=lint serv
 


### PR DESCRIPTION
## Description
Fixed a minor typo in the README where a space was missing after a comma.

## Changes
- Added missing space after comma in "Getting started" section
- Line: "If everything above is done correctly, we can use Verilator..."

## Type of Change
-  Documentation fix
-  Typo correction