### PR TITLE
Change SHARED_RFADDR_IMM_REGS parameter default value

### DIFF
--- a/rtl/serv_immdec.v
+++ b/rtl/serv_immdec.v
@@ -6,7 +6,7 @@
  */
 `default_nettype none
 module serv_immdec
-  #(parameter SHARED_RFADDR_IMM_REGS = 1,
+  #(parameter SHARED_RFADDR_IMM_REGS = 0,
     parameter W = 1)
   (
    input wire 	     i_clk,


### PR DESCRIPTION
According to my AI analysis this "could" save a few LUTs (for FF) or gates

But the total numbers don't match the stats in the "README.md"
=> If someone could validate the idea, it would be great.

### Results:
| Target Platform | Metric | Baseline | Optimized | Change |
| :--- | :--- | :--- | :--- | :--- |
| **iCE40 FPGA** | LUTs | 266 | 258 | **-8 LUTs** |
| **iCE40 FPGA** | FFs | 182 | 194 | +12 FFs |
| **ASIC (Generic CMOS)** | Gates | 1002 | 996 | **-6 Gates** |